### PR TITLE
Add in callback support for when a notify stage is unsupported

### DIFF
--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -217,6 +217,20 @@ exports.notify = function(error, options, cb) {
   }
   //let the default action happen
   options = (options === undefined ? {} : options)
+
+  if(defaultErrorHash.apiKey == "") {
+    var message = "Bugsnag: No apiKey set - not notifying.";
+    console.log(message);
+    //add in support for if we've been given a callback but not got a key, give back an error in the cb
+    if(cb instanceof Function) cb(new Error(message));
+    return;
+  }
+  
+  if(typeof notifyReleaseStages !== "undefined" && notifyReleaseStages !== null && notifyReleaseStages.indexOf(releaseStage) == -1) {
+    //add in support for if we're on an unsupported release stage, dont error out, act like it went to bugsnag ok
+    if(cb instanceof Function) cb(null, null);//main thing here is that Error is null
+    return;
+  }
   
   var errorClass;
   var errorMessage;
@@ -237,18 +251,7 @@ exports.notify = function(error, options, cb) {
   notifyError(errorClass, errorMessage, stacktrace, getUserIdFromOptions(options), getContextFromOptions(options), getMetaDataFromOptions(options), cb);
 }
 
-notifyError = function(errorClass, errorMessage, stacktrace, passedUserId, passedContext, metaData, cb) {
-  if(defaultErrorHash.apiKey == "") {
-    console.log("Bugsnag: No apiKey set - not notifying.");
-    if(cb instanceof Function) cb(null, null);
-    return;
-  }
-  
-  if(typeof notifyReleaseStages !== "undefined" && notifyReleaseStages !== null && notifyReleaseStages.indexOf(releaseStage) == -1) {
-    if(cb instanceof Function) cb(null, null);
-    return;
-  }
-  
+notifyError = function(errorClass, errorMessage, stacktrace, passedUserId, passedContext, metaData, cb) {  
   metaData = (metaData === undefined ? {} : metaData)
   var errorList = [{
     appVersion: appVersion,


### PR DESCRIPTION
When running bugsnag in an environment which is not specified within releaseStages, no callback is called if one is given - need to call callback as though everything went OK for codebase to continue as expected without needing more if statements around code in codebase.

Took the liberty to move a block of code which returns out of notify so that it's a little more efficient, it doesn't need to be within notifyError, seems as though no reason for it not to go in notify. Correct me if I'm wrong :smile: 
