### PR TITLE
Allow `onUncaughtError` to be specified from options

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -64,7 +64,7 @@ module.exports = Configuration = (function() {
     Configuration.notifyPort = options.notifyPort || Configuration.notifyPort;
     Configuration.notifyPath = options.notifyPath || Configuration.notifyPath;
     Configuration.metaData = options.metaData || Configuration.metaData;
-    Configuration.onUncaughtError = options.metaData || Configuration.onUncaughtError;
+    Configuration.onUncaughtError = options.onUncaughtError || Configuration.onUncaughtError;
     if (options.projectRoot != null) {
       Configuration.projectRoot = Utils.fullPath(options.projectRoot);
     }


### PR DESCRIPTION
If the configuration options specify `metaData`, then onUncaughtError is no longer a function and causes additional errors. This fix allows `onUncaughtError` to be specified or correctly fall back to the default.
