### PR TITLE
Don't crash on null error

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -14,9 +14,12 @@ module.exports = Error = (function() {
     if (Utils.typeOf(error) === "string") {
       this.message = error;
       this.errorClass = errorClass || "Error";
-    } else {
+    } else if (error) {
       this.message = error.message;
       this.errorClass = errorClass || error.constructor.name || error.name || "Error";
+    } else {
+      this.message = "[unknown]";
+      this.errorClass = errorClass || "Error";
     }
     callSites = stacktrace.parse(error);
     if (callSites.length === 0) {

--- a/src/error.coffee
+++ b/src/error.coffee
@@ -7,9 +7,13 @@ module.exports = class Error
     if Utils.typeOf(error) == "string"
       @message = error
       @errorClass = errorClass || "Error"
-    else
+    else if error
       @message = error.message
       @errorClass = errorClass || error.constructor.name || error.name || "Error"
+    else
+      @message = "[unknown]"
+      @errorClass = errorClass || "Error"
+
 
     callSites = stacktrace.parse error
     callSites = stacktrace.get() if callSites.length == 0


### PR DESCRIPTION
This happens if you try and debug a stuck process using

```
gdb> print 'v8::V8::TerminateExecution'(0)
```

from
http://remysharp.com/2013/09/11/how-i-fixed-an-anonymous-infinite-loop-in-jsbin/
