### PR TITLE
Add fallbacks to request_info for non-IP scenarios

### DIFF
--- a/lib/request_info.js
+++ b/lib/request_info.js
@@ -25,13 +25,13 @@ module.exports = requestInfo = function(req) {
   }
   if (connection) {
     request.connection = {
-      remoteAddress: connection.remoteAddress,
+      remoteAddress: connection.remoteAddress || req.ip,
       remotePort: connection.remotePort,
       bytesRead: connection.bytesRead,
       bytesWritten: connection.bytesWritten,
-      localPort: address.port,
-      localAddress: address.address,
-      IPVersion: address.family
+      localPort: portNumber,
+      localAddress: address != null ? address.address : void 0,
+      IPVersion: address != null ? address.family : void 0
     };
   }
   return request;

--- a/src/request_info.coffee
+++ b/src/request_info.coffee
@@ -21,13 +21,13 @@ module.exports = requestInfo = (req) ->
 
   if connection
     request.connection = {
-      remoteAddress: connection.remoteAddress
+      remoteAddress: connection.remoteAddress || req.ip
       remotePort: connection.remotePort
       bytesRead: connection.bytesRead
       bytesWritten: connection.bytesWritten
-      localPort: address.port
-      localAddress: address.address
-      IPVersion: address.family
+      localPort: portNumber
+      localAddress: address?.address
+      IPVersion: address?.family
     }
 
   request


### PR DESCRIPTION
The current request_info code assumes the request is bound to an IP
address and port. It is possible to have servers listening on named
pipes or other connection mechanisms (e.g, when running under
`iisnode`), where the connection object does not exist.

We add some sane fallbacks for this scenario to fix some crashes and
provide as much data as is available.

Fixes #26
