### PR TITLE
Support for caused by in node

### DIFF
--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -56,7 +56,7 @@ module.exports = Bugsnag = (function() {
   };
 
   Bugsnag.notify = function(error, options, cb) {
-    var bugsnagError, notification;
+    var bugsnagErrors, notification;
     if (Utils.typeOf(options) === "function") {
       cb = options;
       options = {};
@@ -69,9 +69,9 @@ module.exports = Bugsnag = (function() {
       return;
     }
     Configuration.logger.info("Notifying Bugsnag of exception...\n" + ((error != null ? error.stack : void 0) || error));
-    bugsnagError = new BugsnagError(error, options.errorName);
+    bugsnagErrors = BugsnagError.buildErrors(error, options.errorName);
     delete options.errorName;
-    notification = new Notification(bugsnagError, options);
+    notification = new Notification(bugsnagErrors, options);
     return notification.deliver(cb);
   };
 

--- a/lib/error.js
+++ b/lib/error.js
@@ -9,6 +9,15 @@ Configuration = require("./configuration");
 module.exports = Error = (function() {
   var processCallSites;
 
+  Error.buildErrors = function(error, errorClass) {
+    var returnArray;
+    returnArray = [new module.exports(error, errorClass)];
+    if (error.oauthError) {
+      returnArray.push(new module.exports(error.oauthError));
+    }
+    return returnArray;
+  };
+
   function Error(error, errorClass) {
     var callSites;
     if (Utils.typeOf(error) === "string") {

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -22,13 +22,13 @@ module.exports = Notification = (function() {
 
   SUPPORTED_SEVERITIES = ["error", "warning", "info"];
 
-  function Notification(bugsnagError, options) {
+  function Notification(bugsnagErrors, options) {
     var domainOptions, event, _ref, _ref1, _ref10, _ref11, _ref12, _ref13, _ref14, _ref15, _ref2, _ref3, _ref4, _ref5, _ref6, _ref7, _ref8, _ref9;
     if (options == null) {
       options = {};
     }
     event = {
-      exceptions: [bugsnagError]
+      exceptions: bugsnagErrors
     };
     if (options.userId || (typeof process !== "undefined" && process !== null ? (_ref = process.domain) != null ? (_ref1 = _ref._bugsnagOptions) != null ? _ref1.userId : void 0 : void 0 : void 0)) {
       event.userId = options.userId || (typeof process !== "undefined" && process !== null ? (_ref2 = process.domain) != null ? (_ref3 = _ref2._bugsnagOptions) != null ? _ref3.userId : void 0 : void 0 : void 0);

--- a/src/bugsnag.coffee
+++ b/src/bugsnag.coffee
@@ -50,11 +50,11 @@ module.exports = class Bugsnag
       return
 
     Configuration.logger.info "Notifying Bugsnag of exception...\n#{error?.stack || error}"
-    bugsnagError = new BugsnagError(error, options.errorName)
+    bugsnagErrors = BugsnagError.buildErrors(error, options.errorName)
 
     delete options.errorName
 
-    notification = new Notification(bugsnagError, options)
+    notification = new Notification(bugsnagErrors, options)
     notification.deliver cb
 
   # The error handler express/connect middleware. Performs a notify

--- a/src/error.coffee
+++ b/src/error.coffee
@@ -3,6 +3,12 @@ Utils = require "./utils"
 Configuration = require "./configuration"
 
 module.exports = class Error
+  @buildErrors: (error, errorClass) ->
+    returnArray = [new module.exports(error, errorClass)]
+    returnArray.push(new module.exports(error.oauthError)) if error.oauthError
+
+    returnArray
+
   constructor: (error, errorClass) ->
     if Utils.typeOf(error) == "string"
       @message = error
@@ -18,7 +24,7 @@ module.exports = class Error
 
   processCallSites = (callSites) ->
     return callSites.map (callSite) ->
-      frame = 
+      frame =
         file: callSite.getFileName()
         method: callSite.getMethodName() || callSite.getFunctionName() || "none"
         lineNumber: callSite.getLineNumber()

--- a/src/notification.coffee
+++ b/src/notification.coffee
@@ -12,9 +12,9 @@ module.exports = class Notification
 
   SUPPORTED_SEVERITIES = ["error", "warning", "info"]
 
-  constructor: (bugsnagError, options = {}) ->
+  constructor: (bugsnagErrors, options = {}) ->
     event =
-      exceptions: [bugsnagError]
+      exceptions: bugsnagErrors
 
     event.userId = options.userId || process?.domain?._bugsnagOptions?.userId if options.userId || process?.domain?._bugsnagOptions?.userId
     event.context = options.context || process?.domain?._bugsnagOptions?.context if options.context || process?.domain?._bugsnagOptions?.context

--- a/test/error.coffee
+++ b/test/error.coffee
@@ -1,0 +1,30 @@
+path = require("path")
+should = require("chai").should()
+sinon = require("sinon")
+
+Bugsnag = require "../"
+BugsnagError = require "../lib/error"
+
+apiKey = null
+deliverStub = null
+
+before () ->
+  apiKey = "71ab53572c7b45316fb894d446f2e11d"
+  Bugsnag.register apiKey, notifyReleaseStages: ["production", "development"]
+
+beforeEach ->
+  Bugsnag.configure notifyReleaseStages: ["production", "development"]
+
+describe "Error", ->
+  it "should have one error", ->
+    error = new Error("error")
+    errors = BugsnagError.buildErrors(error)
+
+    errors.length.should.equal 1
+
+  it "should support oath errors", ->
+    error = new Error("error")
+    error.oauthError = new Error("oauth error")
+    errors = BugsnagError.buildErrors(error)
+
+    errors.length.should.equal 2

--- a/test/notification.coffee
+++ b/test/notification.coffee
@@ -141,7 +141,7 @@ describe "Notification", ->
       Bugsnag.notify("This is the message")
 
       deliverStub.firstCall.thisValue.events[0].exceptions[0].stacktrace[0].should.not.have.property("inProject")
-      deliverStub.firstCall.thisValue.events[0].exceptions[0].stacktrace[2].should.have.property("inProject", true)
+      deliverStub.firstCall.thisValue.events[0].exceptions[0].stacktrace[3].should.have.property("inProject", true)
 
   describe "metaData", ->
     it "should allow configured metadata on Bugsnag object", ->


### PR DESCRIPTION
This covers a use case someone had to capture oauthErrors (https://github.com/jaredhanson/passport-oauth2/blob/master/lib/errors/internaloautherror.js#L18)

It would be nice to have support for generic error objects so maybe I could add support for looping through the properties on an error to see if any properties are errors themselves.
