### PR TITLE
Use request module to make HTTP requests, add proxy support

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -23,6 +23,8 @@ module.exports = Configuration = (function() {
 
   Configuration.useSSL = true;
 
+  Configuration.proxy = null;
+
   Configuration.notifyHost = "notify.bugsnag.com";
 
   Configuration.notifyPath = "/";

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -1,4 +1,4 @@
-var Configuration, Logger, Notification, Utils, path, requestInfo,
+var Configuration, Logger, Notification, Utils, path, request, requestInfo,
   __indexOf = [].indexOf || function(item) { for (var i = 0, l = this.length; i < l; i++) { if (i in this && this[i] === item) return i; } return -1; };
 
 Utils = require("./utils");
@@ -10,6 +10,8 @@ Configuration = require("./configuration");
 requestInfo = require("./request_info");
 
 path = require("path");
+
+request = require("request");
 
 module.exports = Notification = (function() {
   var NOTIFIER_NAME, NOTIFIER_URL, NOTIFIER_VERSION, SUPPORTED_SEVERITIES;
@@ -91,7 +93,7 @@ module.exports = Notification = (function() {
   }
 
   Notification.prototype.deliver = function(cb) {
-    var cache, lib, options, payload, port, req;
+    var cache, notifyUrl, options, payload, port;
     if (Utils.typeOf(cb) !== "function") {
       cb = null;
     }
@@ -108,45 +110,33 @@ module.exports = Notification = (function() {
       }
       return value;
     });
+    notifyUrl = "" + (Configuration.useSSL ? "https" : "http") + "://" + Configuration.notifyHost + ":" + port + Configuration.notifyPath;
     options = {
-      host: Configuration.notifyHost,
-      port: port,
-      path: Configuration.notifyPath,
-      method: 'POST',
+      proxy: Configuration.proxy,
+      body: payload,
       headers: {
         "Content-Type": 'application/json',
         "Content-Length": payload.length
       }
     };
     Configuration.logger.info(payload);
-    lib = Configuration.useSSL ? require("https") : require("http");
-    req = lib.request(options, function(res) {
-      var bodyRes;
-      if (cb) {
-        bodyRes = "";
-        res.setEncoding('utf8');
-        return res.on('data', function(chunk) {
-          if (chunk) {
-            return bodyRes += chunk;
-          }
-        }).on('end', function() {
-          if (res.statusCode === 200) {
-            return cb(null, bodyRes);
-          } else {
-            return cb(new Error(bodyRes));
-          }
-        });
-      }
-    });
-    req.on("error", function(err) {
-      if (cb) {
-        return cb(err);
+    return request.post(notifyUrl, options, function(err, res, body) {
+      if (err) {
+        if (cb) {
+          return cb(err);
+        } else {
+          return Configuration.logger.error(err);
+        }
       } else {
-        return Configuration.logger.error(err);
+        if (cb) {
+          if (res.statusCode === 200) {
+            return cb(null, body);
+          } else {
+            return cb(new Error(body));
+          }
+        }
       }
     });
-    req.write(payload, "utf-8");
-    return req.end();
   };
 
   Notification.prototype.processRequest = function(event, cleanRequest) {

--- a/package.json
+++ b/package.json
@@ -5,7 +5,8 @@
     "main": "./lib/bugsnag.js",
     "homepage": "http://bugsnag.com",
     "dependencies": {
-        "stack-trace": ">=0.0.6"
+        "stack-trace": ">=0.0.6",
+        "request": ">=2.36.0"
     },
     "devDependencies": {
         "mocha": "~1.8.0",

--- a/src/configuration.coffee
+++ b/src/configuration.coffee
@@ -12,6 +12,7 @@ module.exports = class Configuration
   @projectRoot: path.dirname require?.main?.filename
   @autoNotifyUncaught: true
   @useSSL: true
+  @proxy: null
   @notifyHost = "notify.bugsnag.com"
   @notifyPath = "/"
   @notifyPort = undefined

--- a/test/express.coffee
+++ b/test/express.coffee
@@ -2,7 +2,7 @@ express = require 'express'
 sinon = require 'sinon'
 assert = require 'assert'
 bugsnag = require "../"
-http = require 'http'
+request = require 'request'
 Notification = require "../lib/notification"
 
 bugsnag.register '00112233445566778899aabbccddeeff'
@@ -28,28 +28,17 @@ describe "express middleware", ->
     port = app.listen().address().port
 
 
-    http.request({
-      host: 'localhost',
-      port: port,
-      path: '/ping',
-      method: 'GET',
-    }, (res) ->
-      res.on 'data', ->
+    request.get "http://localhost:#{port}/ping", (err, res, body) ->
+      assert deliverStub.calledOnce
 
-      res.on 'end', ->
-        console.log 'end'
-        assert deliverStub.calledOnce
+      req = deliverStub.firstCall.thisValue.events[0].metaData.request
 
-        request = deliverStub.firstCall.thisValue.events[0].metaData.request
-
-        assert.equal request.url, "http://localhost:#{port}/ping"
-        assert.equal request.path, "/ping"
-        assert.equal request.method, "GET"
-        assert.equal request.headers.host, "localhost:#{port}"
-        assert.equal request.httpVersion, "1.1"
-        assert.equal request.connection.remoteAddress, "127.0.0.1"
-        assert.equal request.connection.localPort, port
-        assert.equal request.connection.IPVersion, "IPv4"
-        next()
-    ).end()
-
+      assert.equal req.url, "http://localhost:#{port}/ping"
+      assert.equal req.path, "/ping"
+      assert.equal req.method, "GET"
+      assert.equal req.headers.host, "localhost:#{port}"
+      assert.equal req.httpVersion, "1.1"
+      assert.equal req.connection.remoteAddress, "127.0.0.1"
+      assert.equal req.connection.localPort, port
+      assert.equal req.connection.IPVersion, "IPv4"
+      next()


### PR DESCRIPTION
I would like to be able to use bugsnag-node in an environment where I must use a proxy server for outgoing HTTP/HTTPS requests. Instead of adding custom logic for this, I've changed HTTP/HTTPS calls to use the `request` library, which has proxy support built-in (and also abstracts some other things like collecting chunks of response bodies). Is adding an additional dependency for this OK?

The existing tests for sending notifications still pass. All the changes in `lib` are generated from compiling the CoffeeScript in `src`; if I'm not supposed to include those I can remove them.
