### PR TITLE
Fix for TypeError thrown when Request params are not objects

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -75,6 +75,7 @@ module.exports = Configuration = (function() {
     Configuration.metaData = options.metaData || Configuration.metaData;
     Configuration.onUncaughtError = options.onUncaughtError || Configuration.onUncaughtError;
     Configuration.hostname = options.hostname || Configuration.hostname;
+    Configuration.proxy = options.proxy;
     if (options.projectRoot != null) {
       Configuration.projectRoot = Utils.fullPath(options.projectRoot);
     }

--- a/lib/request_info.js
+++ b/lib/request_info.js
@@ -14,13 +14,13 @@ module.exports = requestInfo = function(req) {
     headers: req.headers,
     httpVersion: req.httpVersion
   };
-  if (req.params && Object.keys(req.params).length > 0) {
+  if (req.params && typeof req.params === 'object' && Object.keys(req.params).length > 0) {
     request.params = req.params;
   }
-  if (req.query && Object.keys(req.query).length > 0) {
+  if (req.query && typeof req.params === 'object' && Object.keys(req.query).length > 0) {
     request.query = req.query;
   }
-  if (req.body && Object.keys(req.body).length > 0) {
+  if (req.body && typeof req.params === 'object' && Object.keys(req.body).length > 0) {
     request.body = req.body;
   }
   if (connection) {

--- a/src/request_info.coffee
+++ b/src/request_info.coffee
@@ -15,9 +15,9 @@ module.exports = requestInfo = (req) ->
     headers: req.headers
     httpVersion: req.httpVersion
   }
-  request.params = req.params if req.params && Object.keys(req.params).length > 0
-  request.query = req.query if req.query && Object.keys(req.query).length > 0
-  request.body = req.body if req.body && Object.keys(req.body).length > 0
+  request.params = req.params if req.params && typeof req.params == 'object' && Object.keys(req.params).length > 0
+  request.query = req.query if req.query && typeof req.params == 'object' && Object.keys(req.query).length > 0
+  request.body = req.body if req.body && typeof req.params == 'object' && Object.keys(req.body).length > 0
 
   if connection
     request.connection = {


### PR DESCRIPTION
It is possible for the request body object to be a string. This will throw a TypeError when attempting to use `Object.keys`. 

This fix adds a typeof check to ensure Object.keys is only used on objects.
