### PR TITLE
Expose shouldNotify

### DIFF
--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -18,7 +18,7 @@ Notification = require("./notification");
 Error.stackTraceLimit = Infinity;
 
 module.exports = Bugsnag = (function() {
-  var autoNotifyCallback, shouldNotify, unCaughtErrorHandlerAdded;
+  var autoNotifyCallback, unCaughtErrorHandlerAdded;
 
   function Bugsnag() {}
 
@@ -62,7 +62,7 @@ module.exports = Bugsnag = (function() {
       options = {};
     }
     options || (options = {});
-    if (!shouldNotify()) {
+    if (!Bugsnag.shouldNotify()) {
       if (cb) {
         cb();
       }
@@ -141,7 +141,7 @@ module.exports = Bugsnag = (function() {
     return dom;
   };
 
-  shouldNotify = function() {
+  Bugsnag.shouldNotify = function() {
     return (Configuration.notifyReleaseStages === null || Configuration.notifyReleaseStages.indexOf(Configuration.releaseStage) !== -1) && Configuration.apiKey;
   };
 

--- a/src/bugsnag.coffee
+++ b/src/bugsnag.coffee
@@ -38,14 +38,14 @@ module.exports = class Bugsnag
         @notify err, {severity: "error"}, autoNotifyCallback(err, true)
 
   # Only error is required, and that can be a string or error object
-  @notify: (error, options, cb) ->
+  @notify: (error, options, cb) =>
     if Utils.typeOf(options) == "function"
       cb = options
       options = {}
 
     options ||= {}
 
-    unless shouldNotify()
+    unless @shouldNotify()
       cb() if cb
       return
 
@@ -108,7 +108,7 @@ module.exports = class Bugsnag
 
     return dom
 
-  shouldNotify = ->
+  @shouldNotify: ->
     ( Configuration.notifyReleaseStages == null || Configuration.notifyReleaseStages.indexOf(Configuration.releaseStage) != -1 ) && Configuration.apiKey
 
   autoNotifyCallback = (notifiedError, uncaughtError = notifiedError.domain) ->


### PR DESCRIPTION
Please expose `shouldNotify` function to have the condition to insert the error handler as the event hook affects the performance.

```
if (!Bugsnag.shouldNotify())
  server.on("uncaughtException", bugsnag.restifyHandler);
```

<!-- Reviewable:start -->
[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/bugsnag/bugsnag-node/40)
<!-- Reviewable:end -->
