### PR TITLE
Clean request-info pre-emptively [Fixes #16]?

### DIFF
--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -4,7 +4,8 @@ var domain = require("domain"),
     Logger = require("./logger"),
     Configuration = require("./configuration"),
     BugsnagError = require("./error"),
-    Notification = require("./notification");
+    Notification = require("./notification"),
+    requestInfo = require("./request_info");
 
 // Ensure we get all stack frames from thrown errors.
 Error.stackTraceLimit = Infinity;
@@ -104,7 +105,7 @@ Bugsnag.requestHandler = function(req, res, next) {
     var dom;
     dom = domain.create();
     dom._bugsnagOptions = {
-        req: req
+        cleanedRequest: requestInfo(req)
     };
     dom.on('error', next);
     return dom.run(next);
@@ -113,7 +114,7 @@ Bugsnag.requestHandler = function(req, res, next) {
 Bugsnag.restifyHandler = function(req, res, route, err) {
     Bugsnag.notify(err, {
         req: req,
-            severity: "error"
+        severity: "error"
     }, autoNotifyCallback(err));
 };
 


### PR DESCRIPTION
I managed to replicate a similar problem to this, though I was
getting an out of memory error not a stack size exceeded error.

This was the fix.