### PR TITLE
Rename req.host to req.hostname

### DIFF
--- a/lib/request_info.js
+++ b/lib/request_info.js
@@ -3,7 +3,7 @@ function requestInfo (req) {
     var address = connection && connection.address();
     var portNumber = address && address.port;
     var port = !portNumber || portNumber === 80 || portNumber === 443 ? '' : ':' + portNumber;
-    var full_url = req.protocol + "://" + req.host + port + req.url;
+    var full_url = req.protocol + "://" + (req.hostname || req.host) + port + req.url;
     var request = {
         url: full_url,
         path: req.path || req.url,


### PR DESCRIPTION
Just upgraded to Bugsnag v1.6.0, but express v4.11.2 started logging this warning:

    express deprecated req.host: Use req.hostname instead node_modules/bugsnag/lib/request_info.js:6:46

This should fix this!