### PR TITLE
The request command requires the url to be part of the options hash.

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -151,9 +151,8 @@ Notification.prototype._deliver = function (cb) {
         return value;
     });
 
-    var notifyUrl = "" + (Configuration.useSSL ? "https" : "http") + "://" + Configuration.notifyHost + ":" + port + Configuration.notifyPath;
-
     var options = {
+        url: "" + (Configuration.useSSL ? "https" : "http") + "://" + Configuration.notifyHost + ":" + port + Configuration.notifyPath,
         proxy: Configuration.proxy,
         body: payload,
         headers: {
@@ -164,7 +163,7 @@ Notification.prototype._deliver = function (cb) {
 
     Configuration.logger.info(payload);
 
-    return request.post(notifyUrl, options, function(err, res, body) {
+    return request.post(options, function(err, res, body) {
         if (err) {
             if (cb) {
                 return cb(err);


### PR DESCRIPTION
See: https://github.com/request/request#requestoptions-callback

This fixes a bug where requests weren't being routed through a proxy properly.