### PR TITLE
Handling exception severity based on the http status code

### DIFF
--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -105,9 +105,10 @@ Bugsnag.notify = function(error, options, cb) {
 // The error handler express/connext middleware. Performs a notify
 Bugsnag.errorHandler = function(err, req, res, next) {
     Configuration.logger.info("Handling express error: " + (err.stack || err));
+    var severity = (err.status >= 500) ? "error" : "warning";
     Bugsnag.notify(err, {
         req: req,
-        severity: "error"
+        severity: severity
     }, autoNotifyCallback(err));
     return next(err);
 };
@@ -125,9 +126,10 @@ Bugsnag.requestHandler = function(req, res, next) {
 };
 
 Bugsnag.restifyHandler = function(req, res, route, err) {
+    var severity = (err.status >= 500) ? "error" : "warning";
     Bugsnag.notify(err, {
         req: req,
-        severity: "error"
+        severity: severity
     }, autoNotifyCallback(err));
 };
 


### PR DESCRIPTION
Exception severity qualification:
- `http status code < 500`: `warning`
- `http status code >= 500`: `error`
