### PR TITLE
Relaxes dependency versioning 

### DIFF
--- a/package.json
+++ b/package.json
@@ -5,7 +5,7 @@
     "main": "./lib/bugsnag.js",
     "homepage": "http://bugsnag.com",
     "dependencies": {
-        "promise": "7.0.4",
+        "promise": "7.x",
         "stack-trace": "0.0.9",
         "request": "2.53.0"
     },

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "dependencies": {
         "promise": "7.x",
         "stack-trace": "0.0.9",
-        "request": "2.53.0"
+        "request": "2.x"
     },
     "devDependencies": {
         "mocha": "latest",


### PR DESCRIPTION
Currently both `promise` and `request` versions are pinned which makes it impossible to get patched updates within the same major version, see the commit message to a50469d.

It may require a version bump to 1.7, not sure what your policy is.

All tests are green locally.