### PR TITLE
Remove cleaned request metadata from payload

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -81,8 +81,8 @@ function Notification(bugsnagErrors, options) {
         delete options.req;
     } else if (domainOptions.cleanedRequest) {
         this.processRequest(event, domainOptions.cleanedRequest);
-        delete domainOptions.cleanedRequest;
     }
+    delete domainOptions.cleanedRequest;
 
     if (options.apiKey) {
         this.apiKey = options.apiKey;


### PR DESCRIPTION
Scrubs cleaned request from the payload in the case that both req and
cleanedRequest are set.

Fixes #69