### PR TITLE
Invoke notify callback with errors

### DIFF
--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -91,7 +91,9 @@ Bugsnag.notify = function(error, options, cb) {
     }
     if (!Bugsnag.shouldNotify()) {
         if (cb) {
-            cb();
+            cb(new Error(!Configuration.apiKey ?
+                "Bugsnag has not been configured with an api key!" :
+                "Current release stage not permitted to send events to Bugsnag."));
         }
         return;
     }

--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -91,9 +91,11 @@ Bugsnag.notify = function(error, options, cb) {
     }
     if (!Bugsnag.shouldNotify()) {
         if (cb) {
-            cb(new Error(!Configuration.apiKey ?
-                "Bugsnag has not been configured with an api key!" :
-                "Current release stage not permitted to send events to Bugsnag."));
+            if (!Configuration.apiKey) {
+                cb(new Error("Bugsnag has not been configured with an api key!"));
+            } else {
+                cb(new Error("Current release stage not permitted to send events to Bugsnag."));
+            }
         }
         return;
     }

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -120,6 +120,9 @@ Notification.prototype.deliver = function(cb) {
     }.bind(this));
 
     if (!shouldNotify) {
+        if (cb) {
+            cb(new Error("At least one beforeNotify callback prevented the event from being sent to Bugsnag."));
+        }
         return;
     }
 


### PR DESCRIPTION
This PR ensures that the `callback` argument on the `notify` function is invoked with an error as the first argument when the event is prevented from being sent to Bugsnag.

The situations & their messages are;
- When an API key is not supplied.  
> Error: Bugsnag has not been configured with an api key!

- If the release stage is not included in the `notifyReleaseStages` array.  
> Error: Current release stage not permitted to send events to Bugsnag.

- If a `beforeNotify` callback prevents the event from being sent.  
> Error: At least one beforeNotify callback prevented the event from being sent to Bugsnag.

Fixes #74 