### PR TITLE
Clone Objects Before Filtering and Sending to Bugsnag

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -133,7 +133,7 @@ Notification.prototype._deliver = function (cb) {
     }
 
     // Filter before sending
-    Utils.filterObject(this.events[0].metaData, Configuration.filters);
+    this.events[0].metaData = Utils.filterObject(this.events[0].metaData, Configuration.filters);
 
     var port = Configuration.notifyPort || (Configuration.useSSL ? 443 : 80);
 
@@ -211,4 +211,3 @@ Notification.prototype.loadCode = function (callback) {
 };
 
 module.exports = Notification;
-

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -103,6 +103,7 @@ var Utils = {
         if (Utils.typeOf(filters) !== "array") {
             return;
         }
+        object = this.cloneObject(object);
         var alreadyFiltered = options.alreadyFiltered || [];
         Object.keys(object).forEach(function (key) {
             if (Utils.checkOwnProperty(object, key)) {
@@ -111,13 +112,14 @@ var Utils = {
                         object[key] = "[FILTERED]";
                     } else if (Utils.typeOf(object[key]) === "object" && alreadyFiltered.indexOf(object[key]) === -1) {
                         alreadyFiltered.push(object[key]);
-                        Utils.filterObject(object[key], filters, {
+                        object[key] = Utils.filterObject(object[key], filters, {
                             alreadyFiltered: alreadyFiltered
                         });
                     }
                 });
             }
         });
+        return object;
     }
 };
 

--- a/test/utils.js
+++ b/test/utils.js
@@ -229,7 +229,7 @@
                     firstKey: "firstValue",
                 secondKey: "secondValue"
                 };
-                Utils.filterObject(testObject, ["firstKey"]);
+                testObject = Utils.filterObject(testObject, ["firstKey"]);
                 testObject.should.have.keys(["firstKey", "secondKey"]);
                 testObject.should.have.property("firstKey", "[FILTERED]");
                 testObject.should.have.property("secondKey", "secondValue");
@@ -249,7 +249,7 @@
                 }
                 }
                 };
-                Utils.filterObject(testObject, ["firstKey", "thirdKey", "thirdObject"]);
+                testObject = Utils.filterObject(testObject, ["firstKey", "thirdKey", "thirdObject"]);
                 testObject.should.have.keys(["firstKey", "firstObject"]);
                 testObject.should.have.property("firstKey", "[FILTERED]");
                 testObject.should.have.property("firstObject").should.be.an("object");
@@ -292,7 +292,7 @@
 
                 data.foo = 'bar';
                 data.password = '$secret';
-                Utils.filterObject(data, ['password']);
+                data = Utils.filterObject(data, ['password']);
 
                 data.foo.should.equal('bar')
                 data.password.should.equal('[FILTERED]')


### PR DESCRIPTION
This PR addresses issue #81. It modifies the `filterObject` method to make a copy of the objects it filters and send those to Bugsnag, rather than operating on the data directly, which can potentially break the calling code that is being monitored by Bugsnag. 