### PR TITLE
Create express middlewares factories.

### DIFF
--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -122,6 +122,10 @@ Bugsnag.errorHandler = function(err, req, res, next) {
     return next(err);
 };
 
+Bugsnag.createErrorHandler = function() {
+  return Bugsnag.register.apply(Bugsnag, arguments).errorHandler;
+};
+
 // The request middleware for express/connect. Ensures next(err) is called when there is an error, and
 // tracks the request for manual notifies.
 Bugsnag.requestHandler = function(req, res, next) {
@@ -132,6 +136,10 @@ Bugsnag.requestHandler = function(req, res, next) {
     };
     dom.on('error', next);
     return dom.run(next);
+};
+
+Bugsnag.createRequestHandler = function() {
+  return Bugsnag.register.apply(Bugsnag, arguments).requestHandler;
 };
 
 Bugsnag.restifyHandler = function(req, res, route, err) {


### PR DESCRIPTION
Added support to `createErrorHandler` and `createRequestHandler`.  Both methods have the same signature as `bugsnag.register` (apiKey, options).

Should I add tests cases to these new methods? I am not seeing test-cases for other methods in the `lib/bugsnag` file.
It is ok to call `bugsnag.register` multiple times? Should we verify if it was already called and just configure once?
Where the docs are updated?

Just let me know what do you think of this
Thanks
