### PR TITLE
allow newer versions of stack-trace

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "homepage": "http://bugsnag.com",
     "dependencies": {
         "promise": "7.x",
-        "stack-trace": "0.0.9",
+        "stack-trace": "~0.0.9",
         "request": "2.x"
     },
     "devDependencies": {


### PR DESCRIPTION
stack-trace was recently updated https://github.com/felixge/node-stack-trace/releases/tag/v0.0.10