### PR TITLE
Add in ability to view custom error props in Bugsnag UI

### DIFF
--- a/lib/error.js
+++ b/lib/error.js
@@ -53,13 +53,27 @@ function processCallSites (callSites) {
 }
 
 function Error(error, errorClass) {
-    var callSites;
+    var callSites, defaultErrorProps, customErrorProps;
     if (Utils.typeOf(error) === "string") {
         this.message = error;
         this.errorClass = errorClass || "Error";
     } else if (error) {
         this.message = error.message;
         this.errorClass = errorClass || error.name || error.constructor.name || "Error";
+
+        // Copy across all non-standard properties to the resulting error.
+        defaultErrorProps = ["message", "stack"];
+        customErrorProps = Object.getOwnPropertyNames(error);
+        for (var i = 0; i < customErrorProps.length; i++) {
+            if (defaultErrorProps.indexOf(customErrorProps[i]) !== -1) {
+                continue; // Skip any default props, already handled.
+            }
+            if (!this.metaData) {
+                this.metaData = {};
+            }
+            // Copy across all non-standard properties to the resulting error.
+            this.metaData[customErrorProps[i]] = error[customErrorProps[i]];
+        }
     } else {
         this.message = "[unknown]";
         this.errorClass = errorClass || "Error";

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -12,6 +12,24 @@ var NOTIFIER_NAME = "Bugsnag Node Notifier",
     NOTIFIER_URL = "https://github.com/bugsnag/bugsnag-node",
     SUPPORTED_SEVERITIES = ["error", "warning", "info"];
 
+function copyCustomExceptionProps(exceptions, metaData) {
+    for (var i = 0; i < exceptions.length; i++) {
+        if (exceptions[i].metaData) {
+            if (!metaData) {
+                metaData = {};
+            }
+            if (!Array.isArray(metaData.CustomExceptions)) {
+                metaData.CustomExceptions = [];
+            }
+            // Add all custom props to the "CustomExceptions" tab.
+            metaData.CustomExceptions.push(exceptions[i].metaData);
+            // Delete from exception so we conform to the API spec.
+            delete exceptions[i].metaData; 
+        }
+    }
+    return metaData;
+}
+
 function Notification(bugsnagErrors, options) {
     if (!options) {
         options = {};
@@ -69,6 +87,8 @@ function Notification(bugsnagErrors, options) {
     if (Configuration.metaData && Object.keys(Configuration.metaData).length > 0) {
         event.metaData = Utils.cloneObject(Configuration.metaData);
     }
+
+    event.metaData = copyCustomExceptionProps(event.exceptions, event.metaData);
 
     if (Configuration.hostname) {
         event.device = {

--- a/test/error.js
+++ b/test/error.js
@@ -36,6 +36,19 @@
       errors = BugsnagError.buildErrors(error);
       return errors.length.should.equal(1);
     });
+    it("should copy custom error props", function () {
+      var error, errors, MyError;
+      MyError = function(message, customProp) {
+        this.message = message;
+        this.customProp = customProp;
+      };
+      MyError.prototype = Object.create(Error.prototype);
+      MyError.prototype.constructor = MyError;
+      error = new MyError("error", "custom prop");
+      errors = BugsnagError.buildErrors(error);
+      errors.length.should.equal(1);
+      return errors[0].metaData.customProp.should.equal("custom prop");
+    });
     return it("should support oath errors", function() {
       var error, errors;
       error = new Error("error");


### PR DESCRIPTION
To do:

- [x] Add in support for automatically raising custom attached properties for sub-classed error types.
- [x] Add them in as a "Custom Exceptions" error tab.
- [x] Fix/Add tests.

Gotchas:

- Potentially will cause problems with JSON serialisation when notifying bugsnag, but guessing this is a client consumer anyway so haven't done anything to prevent this.

Fixes: https://github.com/bugsnag/bugsnag-node/issues/101