### PR TITLE
Pass original error to pre-send callbacks

### DIFF
--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -105,10 +105,10 @@ Bugsnag.notify = function(error, options, cb) {
     notification = new Notification(bugsnagErrors, options);
     if (Configuration.sendCode === true) {
         notification.loadCode(function () {
-            notification.deliver(cb);
+            notification.deliver(cb, error);
         });
     } else {
-        notification.deliver(cb);
+        notification.deliver(cb, error);
     }
 };
 

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -108,12 +108,12 @@ function Notification(bugsnagErrors, options) {
     this.events = [event];
 }
 
-Notification.prototype.deliver = function(cb) {
+Notification.prototype.deliver = function(cb, originalError) {
 
     // run before notify callbacks
     var shouldNotify = true;
     Configuration.beforeNotifyCallbacks.forEach(function (callback) {
-        var ret = callback(this);
+        var ret = callback(this, originalError);
         if (ret === false) {
             shouldNotify = false;
         }

--- a/test/notification.js
+++ b/test/notification.js
@@ -297,6 +297,24 @@ describe("Notification", function() {
 
             Configuration.beforeNotifyCallbacks = [];
         });
+
+        it("should allow introspecting the original error object", function () {
+            function SpecialError(message) {
+              this.name = "SpecialError";
+              this.message = message;
+              this.customInfo = {times: "three"};
+            }
+            SpecialError.prototype = Object.create(Error.prototype);
+
+            var error = new SpecialError("there is a glitch");
+            Bugsnag.onBeforeNotify(function (notification, error) {
+              notification.events[0].metaData.customInfo = error.customInfo;
+            });
+            Bugsnag.notify(error);
+            deliverStub.firstCall.thisValue.events[0].metaData.customInfo.should.have.property("times", "three");
+
+            Configuration.beforeNotifyCallbacks = [];
+        });
     });
 
     describe("autoNotify", function() {


### PR DESCRIPTION
Sometimes additional context available on the error instance is needed when creating error reports, which can then be used to attach metadata or decide to cancel the report. This change adds the original error which generated the report as a parameter to `beforeNotifyCallbacks`.

Here's an example of attaching custom error properties (from #101) which is then easily fixable:

```js
// Given a custom error type with additional properties
function SpecialError(message) {
  this.name = "SpecialError";
  this.message = message;
  this.customInfo = {times: "three"};
  this.otherInfo = {bananas: 4};
}
SpecialError.prototype = Object.create(Error.prototype);

// Additional fields can then be attached to the metadata of a report
Bugsnag.onBeforeNotify(function (notification, error) {
  var customInfo = {};
  var defaultProps = ['message', 'stack', 'name'];
  Object.getOwnPropertyNames(error).forEach(function(propName) {
    if (defaultProps.indexOf(propName) == -1)
      customInfo[propName] = error[propName];
  });
  notification.events[0].metaData['Detailed Error Data'] = customInfo;
});
```
The metadata of the report then includes the tab "Detailed Error Data" including the non-default fields.  There is a similar example in the tests. Later I'd like to revisit this case to potentially do this behavior by default.

Fixes #101 