### PR TITLE
Utils: Improve and correct filter/clone

### DIFF
--- a/lib/utils.js
+++ b/lib/utils.js
@@ -39,30 +39,65 @@ var Utils = {
     },
 
     cloneObject:  function(obj, options) {
-        if (!options) {
-            options = {};
-        }
-        if (!(obj && Utils.typeOf(obj) === "object")) {
+        if (!obj) {
             return obj;
         }
-        var except = options.except || [];
-        var alreadyCloned = options.alreadyCloned || [];
-        var copy = {};
-        Object.keys(obj).forEach(function (key) {
-            var val = obj[key];
-            if (Utils.checkOwnProperty(obj, key) && except.indexOf(key) === -1) {
-                if (Utils.typeOf(val) === "object") {
-                    if (alreadyCloned.indexOf(val) === -1) {
-                        alreadyCloned.push(val);
-                        copy[key] = Utils.cloneObject(val, {
-                            alreadyCloned: alreadyCloned
-                        });
-                    }
-                } else {
-                    copy[key] = val;
+
+        if (!options || !options.except || !options.alreadyCloned) {
+            options = options || {};
+            return Utils.cloneObject(obj, {
+                except: options.except || [],
+                exceptHandler: options.exceptHandler,
+                alreadyCloned: options.alreadyCloned || { sources: [], results: [] }
+            });
+        }
+
+        var except = options.except;
+        var exceptHandler = options.exceptHandler;
+        var clonedSources = options.alreadyCloned.sources;
+        var clonedResults = options.alreadyCloned.results;
+
+        var existingIdx = clonedSources.indexOf(obj);
+        if (existingIdx > -1) {
+            return clonedResults[existingIdx];
+        }
+
+        var copy = obj;
+        var type = Utils.typeOf(obj);
+
+        if (type === "object") {
+            copy = {};
+            clonedSources.push(obj);
+            clonedResults.push(copy);
+
+            Object.keys(obj).forEach(function (key) {
+                var val = obj[key];
+                if (!Utils.checkOwnProperty(obj, key)) {
+                    return;
                 }
+
+                if (except.indexOf(key) > -1) {
+                    if (exceptHandler) {
+                        var replacement = exceptHandler(key, val);
+                        if (replacement !== undefined) {
+                            copy[key] = replacement;
+                        }
+                    }
+                    return;
+                }
+
+                copy[key] = Utils.cloneObject(val, options);
+            });
+        } else if (type === "array") {
+            copy = [];
+            clonedSources.push(obj);
+            clonedResults.push(copy);
+
+            for (var i = 0; i < obj.length; ++i) {
+                copy.push(Utils.cloneObject(obj[i], options));
             }
-        });
+        }
+
         return copy;
     },
 
@@ -93,33 +128,19 @@ var Utils = {
         return dest;
     },
 
-    filterObject:  function(object, filters, options) {
-        if (!options) {
-            options = {};
-        }
+    filterObject:  function(object, filters) {
         if (Utils.typeOf(object) !== "object") {
             return;
         }
         if (Utils.typeOf(filters) !== "array") {
             return;
         }
-        object = this.cloneObject(object);
-        var alreadyFiltered = options.alreadyFiltered || [];
-        Object.keys(object).forEach(function (key) {
-            if (Utils.checkOwnProperty(object, key)) {
-                return filters.forEach(function(filter) {
-                    if (key.indexOf(filter) !== -1) {
-                        object[key] = "[FILTERED]";
-                    } else if (Utils.typeOf(object[key]) === "object" && alreadyFiltered.indexOf(object[key]) === -1) {
-                        alreadyFiltered.push(object[key]);
-                        object[key] = Utils.filterObject(object[key], filters, {
-                            alreadyFiltered: alreadyFiltered
-                        });
-                    }
-                });
-            }
-        });
-        return object;
+
+        return Utils.cloneObject(object, { except: filters, exceptHandler: Utils._filterHandler });
+    },
+
+    _filterHandler: function() {
+        return '[FILTERED]';
     }
 };
 


### PR DESCRIPTION
This commit addresses performance issues in Utils.filterObject. When
filtering objects of moderate size the old logic would hang the program
for multiple seconds. Also adds support for filtering objects in arrays
and handling more complex references.