### PR TITLE
Add tests for serializing a payload, improve performance

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -182,7 +182,7 @@ Notification.prototype.serializePayload = function() {
     return JSON.stringify(this, function(key, value) {
         if (Utils.typeOf(value) === "object") {
             if (cache.indexOf(value) !== -1) {
-                return;
+                return "[RECURSIVE]";
             }
             cache.push(value);
         }

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -5,7 +5,8 @@ var Promise = require('promise'),
     Configuration = require("./configuration"),
     requestInfo = require("./request_info"),
     path = require("path"),
-    request = require("request");
+    request = require("request"),
+    stringify = require("json-stringify-safe");
 
 var NOTIFIER_NAME = "Bugsnag Node Notifier",
     NOTIFIER_VERSION = Utils.getPackageVersion(path.join(__dirname, '..', 'package.json')),
@@ -177,16 +178,8 @@ Notification.prototype._deliver = function (cb) {
 };
 
 Notification.prototype.serializePayload = function() {
-    var cache = [];
-
-    return JSON.stringify(this, function(key, value) {
-        if (Utils.typeOf(value) === "object") {
-            if (cache.indexOf(value) !== -1) {
-                return "[RECURSIVE]";
-            }
-            cache.push(value);
-        }
-        return value;
+    return stringify(this, null, null, function() {
+        return "[RECURSIVE]";
     });
 }
 

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -142,18 +142,7 @@ Notification.prototype._deliver = function (cb) {
 
     Configuration.logger.info("Delivering exception to " + (Configuration.useSSL ? "https" : "http") + "://" + Configuration.notifyHost + ":" + port + Configuration.notifyPath);
 
-    // We stringify, ignoring circular structures
-    var cache = [];
-
-    var payload = JSON.stringify(this, function(key, value) {
-        if (Utils.typeOf(value) === "object") {
-            if (cache.indexOf(value) !== -1) {
-                return;
-            }
-            cache.push(value);
-        }
-        return value;
-    });
+    var payload = this.serializePayload();
 
     var headers = Utils.cloneObject(Configuration.headers || {});
     headers["Content-Type"] = "application/json";
@@ -186,6 +175,20 @@ Notification.prototype._deliver = function (cb) {
         }
     });
 };
+
+Notification.prototype.serializePayload = function() {
+    var cache = [];
+
+    return JSON.stringify(this, function(key, value) {
+        if (Utils.typeOf(value) === "object") {
+            if (cache.indexOf(value) !== -1) {
+                return;
+            }
+            cache.push(value);
+        }
+        return value;
+    });
+}
 
 Notification.prototype.processRequest = function(event, cleanRequest) {
     if (!event.metaData) {

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dependencies": {
         "promise": "7.x",
         "stack-trace": "~0.0.9",
-        "request": "^2.81.0"
+        "request": "^2.81.0",
+        "json-stringify-safe": "~5.0.1"
     },
     "devDependencies": {
         "mocha": "latest",

--- a/test/notification.js
+++ b/test/notification.js
@@ -113,6 +113,19 @@ describe("Notification", function() {
         payloadObject.items.nestedNotification.should.equal("[RECURSIVE]");
     });
 
+    it("should handle identical sibling fields in the payload", function() {
+        Bugsnag.onBeforeNotify(function(notification) {
+          var obj = { foo: 'bar' };
+          notification.items = { a: obj, b: obj };
+          return true;
+        });
+        Bugsnag.notify("This is the message");
+        var payload = deliverStub.firstCall.thisValue.serializePayload();
+        var payloadObject = JSON.parse(payload)
+        payloadObject.items.a.foo.should.equal('bar');
+        payloadObject.items.b.foo.should.equal('bar');
+    });
+
     describe("payloadVersion", function() {
         it("should have a payloadVersion", function() {
             Bugsnag.notify("This is the message");

--- a/test/notification.js
+++ b/test/notification.js
@@ -110,7 +110,7 @@ describe("Notification", function() {
         Bugsnag.notify("This is the message");
         var payload = deliverStub.firstCall.thisValue.serializePayload();
         var payloadObject = JSON.parse(payload)
-        payloadObject.items.should.not.have.keys("nestedNotification");
+        payloadObject.items.nestedNotification.should.equal("[RECURSIVE]");
     });
 
     describe("payloadVersion", function() {


### PR DESCRIPTION
Added a few tests for avoiding circular references when serializing a `Notification` to JSON. It revealed some false positives around sibling objects, and generally poor performance overall since a reference to every object encountered is kept until the process is complete. 

The existing serialization and cycle detection logic was replaced with [`json-stringify-safe`](https://github.com/isaacs/json-stringify-safe), which handles the test cases correctly.

Fixes #96