### PR TITLE
Handle and report invalid notify(err) argument. Fixes #110.

### DIFF
--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -116,6 +116,13 @@ Bugsnag.notify = function(error, options, cb) {
     if (!options) {
         options = {};
     }
+    if ((!error && typeof error !== "string") || error === true) {
+        Configuration.logger.error("Bugsnag.notify(error…) accepts an object or a string but was called with '" + error + "'");
+        options.metaData = {
+            "notify() arguments": JSON.stringify([].map.call(arguments, function(arg) { return arg }), Utils.sensibleReplacer, 2)
+        };
+        error = new Error("[Bugsnag] Bugsnag.notify(error…) accepts an object or a string but was called with '" + error + "'");
+    }
     if (!Bugsnag.shouldNotify()) {
         if (cb) {
             if (!Configuration.apiKey) {

--- a/lib/utils.js
+++ b/lib/utils.js
@@ -143,6 +143,16 @@ var Utils = {
 
     _filterHandler: function() {
         return '[FILTERED]';
+    },
+
+    // this custom replacer (for use in JSON.stringify(obj, replacer, spaces)) is implemented to
+    // ensure values such as `undefined` and `Function` get serialized in a sensible way. Otherwise
+    // `Function`s get removed and `undefined` gets converted to null, which would be misleading if
+    // you are trying to accurately represent an actual JS object.
+    sensibleReplacer:  function (key, value) {
+        if (value === undefined) return "undefined";
+        if (typeof value === "function") return value.name ? ("[function " + value.name + "()]") : "[anonymous function]";
+        return value;
     }
 };
 

--- a/test/notification.js
+++ b/test/notification.js
@@ -367,4 +367,30 @@ describe("Notification", function() {
             });
         });
     });
+
+    describe("bad input", function() {
+        it("notify(err) should handle bad input", function () {
+          should.not.throw(function () {
+              Bugsnag.notify(null);
+          });
+          should.not.throw(function () {
+              Bugsnag.notify(undefined);
+          });
+          should.not.throw(function () {
+              Bugsnag.notify(0);
+          });
+          should.not.throw(function () {
+              Bugsnag.notify([]);
+          });
+          should.not.throw(function () {
+              Bugsnag.notify(new Date());
+          });
+          should.not.throw(function () {
+              Bugsnag.notify(false);
+          });
+          should.not.throw(function () {
+              Bugsnag.notify(true);
+          });
+        });
+    });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -349,4 +349,10 @@ describe("utils", function() {
             data.password.should.equal('[FILTERED]')
         });
     });
+
+    describe("sensibleReplacer", function () {
+        JSON.stringify({ a: undefined }, Utils.sensibleReplacer).should.equal("{\"a\":\"undefined\"}");
+        JSON.stringify({ a: function () {} }, Utils.sensibleReplacer).should.equal("{\"a\":\"[function a()]\"}");
+        JSON.stringify({ a: [ function () {} ] }, Utils.sensibleReplacer).should.equal("{\"a\":[\"[anonymous function]\"]}");
+    });
 });

--- a/test/utils.js
+++ b/test/utils.js
@@ -352,7 +352,7 @@ describe("utils", function() {
 
     describe("sensibleReplacer", function () {
         JSON.stringify({ a: undefined }, Utils.sensibleReplacer).should.equal("{\"a\":\"undefined\"}");
-        JSON.stringify({ a: function () {} }, Utils.sensibleReplacer).should.equal("{\"a\":\"[function a()]\"}");
+        JSON.stringify({ a: function a() {} }, Utils.sensibleReplacer).should.equal("{\"a\":\"[function a()]\"}");
         JSON.stringify({ a: [ function () {} ] }, Utils.sensibleReplacer).should.equal("{\"a\":[\"[anonymous function]\"]}");
     });
 });


### PR DESCRIPTION
`notify(err…)` now catches and reports the case where `err=null|undefined|0|true|false`.

An error-level log is printed and Error is constructed and sent to Bugsnag with the offending parameter. All of the arguments are captured and sent in the report's metadata too, to help provide context for when this happens.