### PR TITLE
Auto unhandled rejection

### DIFF
--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -44,7 +44,8 @@ function autoNotifyCallback(notifiedError, uncaughtError) {
     };
 }
 
-var unCaughtErrorHandlerAdded = false;
+var unCaughtErrorHandlerAdded = false,
+    unhandledRejectionHandlerAdded = false;
 
 var Bugsnag = {};
 
@@ -99,6 +100,16 @@ Bugsnag.configure = function(options) {
         unCaughtErrorHandlerAdded = true;
         Configuration.logger.info("Configuring uncaughtExceptionHandler");
         process.on("uncaughtException", function(err) {
+            Bugsnag.notify(err, {
+                severity: "error"
+            }, autoNotifyCallback(err, true));
+        });
+    }
+
+    if (Configuration.autoNotifyUnhandledRejection && !unhandledRejectionHandlerAdded) {
+        unhandledRejectionHandlerAdded = true;
+        Configuration.logger.info("Configuring unhandledRejectionHandler");
+        process.on("unhandledRejection", function(err) {
             Bugsnag.notify(err, {
                 severity: "error"
             }, autoNotifyCallback(err, true));

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -11,6 +11,7 @@ var Configuration = {
     notifyReleaseStages: null,
     projectRoot: require.main !== undefined && require.main.filename !== undefined ? path.dirname(require.main.filename) : null,
     autoNotifyUncaught: true,
+    autoNotifyUnhandledRejection: true,
     useSSL: true,
     proxy: null,
     headers: {},
@@ -52,6 +53,7 @@ var Configuration = {
         Configuration.releaseStage = options.releaseStage || Configuration.releaseStage;
         Configuration.appVersion = options.appVersion || Configuration.appVersion;
         Configuration.autoNotifyUncaught = options.autoNotify != null ? options.autoNotify : Configuration.autoNotifyUncaught;
+        Configuration.autoNotifyUnhandledRejection = options.autoNotify != null ? options.autoNotify : Configuration.autoNotifyUnhandledRejection;
         Configuration.useSSL = options.useSSL != null ? options.useSSL : Configuration.useSSL;
         Configuration.filters = options.filters || Configuration.filters;
         Configuration.notifyReleaseStages = options.notifyReleaseStages || Configuration.notifyReleaseStages;

--- a/test/lib/process-uncaught-exception.js
+++ b/test/lib/process-uncaught-exception.js
@@ -1,0 +1,12 @@
+var bugsnag = require("../../"),
+    Notification = require("../../lib/notification"),
+    sinon = require("sinon");
+
+bugsnag.register("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+var deliverStub = sinon.stub(Notification.prototype, "_deliver").yields(null, {});
+process.on("exit", function (code) {
+    process.send({ deliverCalled: deliverStub.called });
+});
+
+throw new Error("Boom");

--- a/test/lib/process-unhandled-rejection.js
+++ b/test/lib/process-unhandled-rejection.js
@@ -1,0 +1,12 @@
+var bugsnag = require("../../"),
+    Notification = require("../../lib/notification"),
+    sinon = require("sinon");
+
+bugsnag.register("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+var deliverStub = sinon.stub(Notification.prototype, "_deliver").yields(null, {});
+process.on("exit", function (code) {
+    process.send({ deliverCalled: deliverStub.called });
+});
+
+Promise.reject(new Error("boom"));

--- a/test/notification.js
+++ b/test/notification.js
@@ -8,7 +8,8 @@ var path = require("path"),
     Notification = require("../lib/notification"),
     request = require("request"),
     apiKey = null,
-    deliverStub = null;
+    deliverStub = null,
+    child_process = require("child_process");
 
 before(function() {
     apiKey = "71ab53572c7b45316fb894d446f2e11d";
@@ -364,6 +365,34 @@ describe("Notification", function() {
                     }
                 });
                 throw new Error();
+            });
+        });
+    });
+
+    describe("dealing with process unhandled/uncaught events", function () {
+        it("should automatically report process#uncaughtException events", function (done) {
+            var p = child_process.fork(__dirname + "/lib/process-uncaught-exception.js");
+            var deliverCalled = false;
+            p.on("message", function (msg) {
+                deliverCalled = msg.deliverCalled;
+            });
+            p.on("exit", function (code) {
+                code.should.equal(1);
+                deliverCalled.should.equal(true);
+                done();
+            });
+        });
+
+        it("should automatically report process#unhandledRejection events", function (done) {
+            var p = child_process.fork(__dirname + "/lib/process-unhandled-rejection.js");
+            var deliverCalled = false;
+            p.on("message", function (msg) {
+                deliverCalled = msg.deliverCalled;
+            });
+            p.on("exit", function (code) {
+                code.should.equal(1);
+                deliverCalled.should.equal(true);
+                done();
             });
         });
     });


### PR DESCRIPTION
Unhandled Promise rejections are now dealt with in the same way as uncaught exceptions:

- error is sent to Bugsnag
- error is logged
- process is shut down with a non-zero exit code (1)

Although this is a _"good"_ change, this can be definitely be considered a breaking change. Recovering from unhandled promise rejections is, as with uncaught exceptions, a terrible idea but if people are relying their processes to continue after such conditions, this change will break that behaviour.

So even though this is a very minor feature addition, this should be a semver major release in my opinion.