### PR TITLE
Handled/unhandled payload properties

### DIFF
--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -12,8 +12,7 @@ var domain = require("domain"),
 // Ensure we get all stack frames from thrown errors.
 Error.stackTraceLimit = Infinity;
 
-// This function is private to the module scope, because `handledState` is not allowed
-// to be set by the user
+// This function is private to the module scope, because `handledState` is not allowed to be set by the user
 function notify (error, options, handledState, cb) {
     var bugsnagErrors, notification;
     if ((!error && typeof error !== "string") || error === true) {

--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -12,6 +12,40 @@ var domain = require("domain"),
 // Ensure we get all stack frames from thrown errors.
 Error.stackTraceLimit = Infinity;
 
+// This function is private to the module scope, because `handledState` is not allowed
+// to be set by the user
+function notify (error, options, handledState, cb) {
+    var bugsnagErrors, notification;
+    if ((!error && typeof error !== "string") || error === true) {
+        Configuration.logger.error("Bugsnag.notify(error…) accepts an object or a string but was called with '" + error + "'");
+        options.metaData = {
+            "notify() arguments": JSON.stringify([].map.call(arguments, function(arg) { return arg }), Utils.sensibleReplacer, 2)
+        };
+        error = new Error("[Bugsnag] Bugsnag.notify(error…) accepts an object or a string but was called with '" + error + "'");
+    }
+    if (!Bugsnag.shouldNotify()) {
+        if (cb) {
+            if (!Configuration.apiKey) {
+                cb(new Error("Bugsnag has not been configured with an api key!"));
+            } else {
+                cb(new Error("Current release stage not permitted to send events to Bugsnag."));
+            }
+        }
+        return;
+    }
+    Configuration.logger.info("Notifying Bugsnag of exception...\n" + (error && error.stack || error));
+    bugsnagErrors = BugsnagError.buildErrors(error, options.errorName);
+    delete options.errorName;
+    notification = new Notification(bugsnagErrors, options, handledState);
+    if (Configuration.sendCode === true) {
+        notification.loadCode(function () {
+            notification.deliver(cb, error);
+        });
+    } else {
+        notification.deliver(cb, error);
+    }
+};
+
 // Will ensure errors still logged if shouldNotify is false
 function autoNotifyCallback(notifiedError, uncaughtError) {
     if (!uncaughtError) {
@@ -100,8 +134,12 @@ Bugsnag.configure = function(options) {
         unCaughtErrorHandlerAdded = true;
         Configuration.logger.info("Configuring uncaughtExceptionHandler");
         process.on("uncaughtException", function(err) {
-            Bugsnag.notify(err, {
+            notify(err, {
                 severity: "error"
+            }, {
+              defaultSeverity: true,
+              unhandled: true,
+              severityReason: { type: "exception_handler" }
             }, autoNotifyCallback(err, true));
         });
     }
@@ -110,8 +148,12 @@ Bugsnag.configure = function(options) {
         unhandledRejectionHandlerAdded = true;
         Configuration.logger.info("Configuring unhandledRejectionHandler");
         process.on("unhandledRejection", function(err) {
-            Bugsnag.notify(err, {
+            notify(err, {
                 severity: "error"
+            }, {
+              defaultSeverity: true,
+              unhandled: true,
+              severityReason: { type: "promise_rejection" }
             }, autoNotifyCallback(err, true));
         });
     }
@@ -119,50 +161,30 @@ Bugsnag.configure = function(options) {
 
 // Only error is required and that can be a string or error object
 Bugsnag.notify = function(error, options, cb) {
-    var bugsnagErrors, notification;
-    if (Utils.typeOf(options) === "function") {
-        cb = options;
-        options = {};
-    }
-    if (!options) {
-        options = {};
-    }
-    if ((!error && typeof error !== "string") || error === true) {
-        Configuration.logger.error("Bugsnag.notify(error…) accepts an object or a string but was called with '" + error + "'");
-        options.metaData = {
-            "notify() arguments": JSON.stringify([].map.call(arguments, function(arg) { return arg }), Utils.sensibleReplacer, 2)
-        };
-        error = new Error("[Bugsnag] Bugsnag.notify(error…) accepts an object or a string but was called with '" + error + "'");
-    }
-    if (!Bugsnag.shouldNotify()) {
-        if (cb) {
-            if (!Configuration.apiKey) {
-                cb(new Error("Bugsnag has not been configured with an api key!"));
-            } else {
-                cb(new Error("Current release stage not permitted to send events to Bugsnag."));
-            }
-        }
-        return;
-    }
-    Configuration.logger.info("Notifying Bugsnag of exception...\n" + (error && error.stack || error));
-    bugsnagErrors = BugsnagError.buildErrors(error, options.errorName);
-    delete options.errorName;
-    notification = new Notification(bugsnagErrors, options);
-    if (Configuration.sendCode === true) {
-        notification.loadCode(function () {
-            notification.deliver(cb, error);
-        });
-    } else {
-        notification.deliver(cb, error);
-    }
-};
+  if (Utils.typeOf(options) === "function") {
+      cb = options;
+      options = {};
+  }
+  if (!options) {
+      options = {};
+  }
+  return notify(error, options, {
+      defaultSeverity: options.severity === undefined,
+      unhandled: false,
+      severityReason: undefined
+  }, cb);
+}
 
 // The error handler express/connext middleware. Performs a notify
 Bugsnag.errorHandler = function(err, req, res, next) {
     Configuration.logger.info("Handling express error: " + (err.stack || err));
-    Bugsnag.notify(err, {
+    notify(err, {
         req: req,
         severity: "error"
+    }, {
+      defaultSeverity: true,
+      unhandled: true,
+      severityReason: { type: "middleware_handler", name: "express/connect" }
     }, autoNotifyCallback(err));
     return next(err);
 };
@@ -188,9 +210,13 @@ Bugsnag.createRequestHandler = function() {
 };
 
 Bugsnag.restifyHandler = function(req, res, route, err) {
-    Bugsnag.notify(err, {
+    notify(err, {
         req: req,
         severity: "error"
+    }, {
+      defaultSeverity: true,
+      unhandled: true,
+      severityReason: { type: "middleware_handler", name: "restify" }
     }, autoNotifyCallback(err));
 };
 
@@ -200,15 +226,23 @@ Bugsnag.koaHandler = function(err, ctx) {
     request = ctx.req;
     request.protocol = ctx.request.protocol;
     request.host = ctx.request.host.split(':', 1)[0];
-    return Bugsnag.notify(err, Object.assign({
+    return notify(err, Object.assign({
         req: request,
         severity: "error"
-    }, ctx.bugsnag), autoNotifyCallback(err));
+    }, ctx.bugsnag), {
+      defaultSeverity: true,
+      unhandled: true,
+      severityReason: { type: "middleware_handler", name: "koa" }
+    }, autoNotifyCallback(err));
 };
 
 // Intercepts the first argument from a callback and interprets it as an error.
 // if the error is not null it notifies bugsnag and doesn't call the callback
-Bugsnag.intercept = function(cb) {
+Bugsnag.intercept = function(options, cb) {
+    if (Utils.typeOf(options) === "function") {
+        cb = options;
+        options = {};
+    }
     if (!cb) {
         cb = (function() {});
     }
@@ -219,9 +253,7 @@ Bugsnag.intercept = function(cb) {
             var err = arguments[0];
             var args = Array.prototype.slice.call(arguments, 1);
             if (err && (err instanceof Error)) {
-                return Bugsnag.notify(err, {
-                    severity: "error"
-                }, autoNotifyCallback(err));
+                return Bugsnag.notify(err, options, autoNotifyCallback(err));
             }
             if (cb) {
                 return cb.apply(null, args);

--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -133,12 +133,10 @@ Bugsnag.configure = function(options) {
         unCaughtErrorHandlerAdded = true;
         Configuration.logger.info("Configuring uncaughtExceptionHandler");
         process.on("uncaughtException", function(err) {
-            notify(err, {
-                severity: "error"
-            }, {
-              defaultSeverity: true,
+            notify(err, {}, {
+              originalSeverity: "error",
               unhandled: true,
-              severityReason: { type: "exception_handler" }
+              severityReason: { type: "unhandledException" }
             }, autoNotifyCallback(err, true));
         });
     }
@@ -147,12 +145,10 @@ Bugsnag.configure = function(options) {
         unhandledRejectionHandlerAdded = true;
         Configuration.logger.info("Configuring unhandledRejectionHandler");
         process.on("unhandledRejection", function(err) {
-            notify(err, {
-                severity: "error"
-            }, {
-              defaultSeverity: true,
+            notify(err, {}, {
+              originalSeverity: "error",
               unhandled: true,
-              severityReason: { type: "promise_rejection" }
+              severityReason: { type: "unhandledPromiseRejection" }
             }, autoNotifyCallback(err, true));
         });
     }
@@ -168,9 +164,9 @@ Bugsnag.notify = function(error, options, cb) {
       options = {};
   }
   return notify(error, options, {
-      defaultSeverity: options.severity === undefined,
+      originalSeverity: "warning",
       unhandled: false,
-      severityReason: undefined
+      severityReason: { type: 'handledException' }
   }, cb);
 }
 
@@ -179,11 +175,10 @@ Bugsnag.errorHandler = function(err, req, res, next) {
     Configuration.logger.info("Handling express error: " + (err.stack || err));
     notify(err, {
         req: req,
-        severity: "error"
     }, {
-      defaultSeverity: true,
+      originalSeverity: "error",
       unhandled: true,
-      severityReason: { type: "middleware_handler", name: "express/connect" }
+      severityReason: { type: "unhandledErrorMiddleware", attributes: { framework: "Express/Connect" } }
     }, autoNotifyCallback(err));
     return next(err);
 };
@@ -210,12 +205,11 @@ Bugsnag.createRequestHandler = function() {
 
 Bugsnag.restifyHandler = function(req, res, route, err) {
     notify(err, {
-        req: req,
-        severity: "error"
+        req: req
     }, {
-      defaultSeverity: true,
+      originalSeverity: "error",
       unhandled: true,
-      severityReason: { type: "middleware_handler", name: "restify" }
+      severityReason: { type: "unhandledErrorMiddleware", attributes: { framework: "Restify" } }
     }, autoNotifyCallback(err));
 };
 
@@ -226,12 +220,11 @@ Bugsnag.koaHandler = function(err, ctx) {
     request.protocol = ctx.request.protocol;
     request.host = ctx.request.host.split(':', 1)[0];
     return notify(err, Object.assign({
-        req: request,
-        severity: "error"
+        req: request
     }, ctx.bugsnag), {
-      defaultSeverity: true,
+      originalSeverity: "error",
       unhandled: true,
-      severityReason: { type: "middleware_handler", name: "koa" }
+      severityReason: { type: "unhandledErrorMiddleware", attributes: { framework: "Koa" } }
     }, autoNotifyCallback(err));
 };
 
@@ -252,7 +245,11 @@ Bugsnag.intercept = function(options, cb) {
             var err = arguments[0];
             var args = Array.prototype.slice.call(arguments, 1);
             if (err && (err instanceof Error)) {
-                return Bugsnag.notify(err, options, autoNotifyCallback(err));
+                return notify(err, options, {
+                  originalSeverity: "warning",
+                  unhandled: false,
+                  severityReason: { type: "callbackErrorIntercept" }
+                }, autoNotifyCallback(err));
             }
             if (cb) {
                 return cb.apply(null, args);
@@ -272,9 +269,12 @@ Bugsnag.autoNotify = function(options, cb) {
     }
     dom = domain.create();
     dom._bugsnagOptions = options;
-    options.severity = "error";
     dom.on('error', function(err) {
-        return Bugsnag.notify(err, options, autoNotifyCallback(err));
+        return notify(err, options, {
+            originalSeverity: "error",
+            unhandled: true,
+            severityReason: { type: "unhandledException" }
+        }, autoNotifyCallback(err, true));
     });
     process.nextTick(function() {
         return dom.run(cb);

--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -44,7 +44,8 @@ function autoNotifyCallback(notifiedError, uncaughtError) {
     };
 }
 
-var unCaughtErrorHandlerAdded = false;
+var unCaughtErrorHandlerAdded = false,
+    unhandledRejectionHandlerAdded = false;
 
 var Bugsnag = {};
 
@@ -99,6 +100,16 @@ Bugsnag.configure = function(options) {
         unCaughtErrorHandlerAdded = true;
         Configuration.logger.info("Configuring uncaughtExceptionHandler");
         process.on("uncaughtException", function(err) {
+            Bugsnag.notify(err, {
+                severity: "error"
+            }, autoNotifyCallback(err, true));
+        });
+    }
+
+    if (Configuration.autoNotifyUnhandledRejection && !unhandledRejectionHandlerAdded) {
+        unhandledRejectionHandlerAdded = true;
+        Configuration.logger.info("Configuring unhandledRejectionHandler");
+        process.on("unhandledRejection", function(err) {
             Bugsnag.notify(err, {
                 severity: "error"
             }, autoNotifyCallback(err, true));

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -11,6 +11,7 @@ var Configuration = {
     notifyReleaseStages: null,
     projectRoot: require.main !== undefined && require.main.filename !== undefined ? path.dirname(require.main.filename) : null,
     autoNotifyUncaught: true,
+    autoNotifyUnhandledRejection: true,
     useSSL: true,
     proxy: null,
     headers: {},
@@ -52,6 +53,7 @@ var Configuration = {
         Configuration.releaseStage = options.releaseStage || Configuration.releaseStage;
         Configuration.appVersion = options.appVersion || Configuration.appVersion;
         Configuration.autoNotifyUncaught = options.autoNotify != null ? options.autoNotify : Configuration.autoNotifyUncaught;
+        Configuration.autoNotifyUnhandledRejection = options.autoNotify != null ? options.autoNotify : Configuration.autoNotifyUnhandledRejection;
         Configuration.useSSL = options.useSSL != null ? options.useSSL : Configuration.useSSL;
         Configuration.filters = options.filters || Configuration.filters;
         Configuration.notifyReleaseStages = options.notifyReleaseStages || Configuration.notifyReleaseStages;

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -62,22 +62,9 @@ function Notification(bugsnagErrors, options, handledState) {
         event.payloadVersion = Configuration.payloadVersion;
     }
 
-
-    event.defaultSeverity = handledState.defaultSeverity;
-    event.unhandled = handledState.unhandled;
-    event.severityReason = handledState.severityReason;
-
-    if (options.severity && SUPPORTED_SEVERITIES.indexOf(options.severity) >= 0) {
-        event.severity = options.severity;
-    } else {
-        event.severity = "warning";
-        // If defaultSeverity was set to false but we got here, i.e. the user set
-        // it to something that wasnt in SUPPORTED_SEVERITIES, that value has now
-        // been set to the default value – "warning".
-        // The event now does how have the default severity so we annotate it
-        // appropriately.
-        event.defaultSeverity = true;
-    }
+    // severity and handledState
+    if (options.severity) event.severity = options.severity;
+    this.handledState = handledState;
 
     if (Configuration.metaData && Object.keys(Configuration.metaData).length > 0) {
         event.metaData = Utils.cloneObject(Configuration.metaData);
@@ -123,15 +110,18 @@ function Notification(bugsnagErrors, options, handledState) {
 
 Notification.prototype.deliver = function(cb, originalError) {
 
-    // save handledState properties, because the user shouldn't be able to set them
-    var before = {
-        severity: this.events[0].severity,
-        defaultSeverity: this.events[0].defaultSeverity,
-        unhandled: this.events[0].unhandled,
-        severityReason: this.events[0].severityReason
+    // did the user set severity?
+    var userSeverity = this.events[0].severity;
+    var userSpecifiedSeverity = userSeverity && userSeverity !== this.handledState.originalSeverity;
+
+    // annotate this property so that we can check if the "beforeNotify" callbacks changed it
+    // can't annotate a string literal ""/'', so create a String() object, woo!
+    if (userSpecifiedSeverity) {
+      this.events[0].severity = new String(userSpecifiedSeverity);
+      this.events[0].severity.__userSpecifiedSeverity = true;
     }
 
-    // run before notify callbacks
+    // run "beforeNotify" callbacks
     var shouldNotify = true;
     Configuration.beforeNotifyCallbacks.forEach(function (callback) {
         var ret = callback(this, originalError);
@@ -140,21 +130,32 @@ Notification.prototype.deliver = function(cb, originalError) {
         }
     }.bind(this));
 
+    // did any of the the callbacks set the severity?
+    var callbackSeverity = this.events[0].severity;
+    var callbackSetSeverity = callbackSeverity && !callbackSeverity.__userSpecifiedSeverity && callbackSeverity !== this.handledState.originalSeverity;
+
+    if (callbackSetSeverity && SUPPORTED_SEVERITIES.indexOf(callbackSeverity) !== -1) {
+        // callbacks set a valid severity value
+        this.events[0].severity = callbackSeverity;
+        this.events[0].severityReason = { type: "userCallbackSetSeverity" };
+    } else if (userSpecifiedSeverity && SUPPORTED_SEVERITIES.indexOf(userSeverity) !== -1) {
+        // user specified a valid severity value
+        this.events[0].severity = userSeverity;
+        this.events[0].severityReason = { type: "userSpecifiedSeverity" };
+    } else {
+        // user did not specify severity, or specified and invalid value
+        this.events[0].severity = this.handledState.originalSeverity;
+        this.events[0].severityReason = this.handledState.severityReason;
+    }
+
+    // finally, add whether the error was unhandled so that callbacks can't fiddle with it
+    this.events[0].unhandled = this.handledState.unhandled;
+
     if (!shouldNotify) {
         if (cb) {
             cb(new Error("At least one beforeNotify callback prevented the event from being sent to Bugsnag."));
         }
         return;
-    }
-
-    // reinstate handledState properties
-    this.events[0].defaultSeverity = before.defaultSeverity
-    this.events[0].unhandled = before.unhandled
-    this.events[0].severityReason = before.severityReason
-
-    // but do one last check to see if severity was changed as a result of the callback(s)
-    if (before.severity !== this.events[0].severity) {
-        this.events[0].defaultSeverity = false;
     }
 
     this._deliver(cb);

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -123,6 +123,14 @@ function Notification(bugsnagErrors, options, handledState) {
 
 Notification.prototype.deliver = function(cb, originalError) {
 
+    // save handledState properties, because the user shouldn't be able to set them
+    var before = {
+        severity: this.events[0].severity,
+        defaultSeverity: this.events[0].defaultSeverity,
+        unhandled: this.events[0].unhandled,
+        severityReason: this.events[0].severityReason
+    }
+
     // run before notify callbacks
     var shouldNotify = true;
     Configuration.beforeNotifyCallbacks.forEach(function (callback) {
@@ -137,6 +145,16 @@ Notification.prototype.deliver = function(cb, originalError) {
             cb(new Error("At least one beforeNotify callback prevented the event from being sent to Bugsnag."));
         }
         return;
+    }
+
+    // reinstate handledState properties
+    this.events[0].defaultSeverity = before.defaultSeverity
+    this.events[0].unhandled = before.unhandled
+    this.events[0].severityReason = before.severityReason
+
+    // but do one last check to see if severity was changed as a result of the callback(s)
+    if (before.severity !== this.events[0].severity) {
+        this.events[0].defaultSeverity = false;
     }
 
     this._deliver(cb);

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -14,7 +14,7 @@ var NOTIFIER_NAME = "Bugsnag Node Notifier",
     NOTIFIER_URL = "https://github.com/bugsnag/bugsnag-node",
     SUPPORTED_SEVERITIES = ["error", "warning", "info"];
 
-function Notification(bugsnagErrors, options) {
+function Notification(bugsnagErrors, options, handledState) {
     if (!options) {
         options = {};
     }
@@ -62,10 +62,21 @@ function Notification(bugsnagErrors, options) {
         event.payloadVersion = Configuration.payloadVersion;
     }
 
+
+    event.defaultSeverity = handledState.defaultSeverity;
+    event.unhandled = handledState.unhandled;
+    event.severityReason = handledState.severityReason;
+
     if (options.severity && SUPPORTED_SEVERITIES.indexOf(options.severity) >= 0) {
         event.severity = options.severity;
     } else {
         event.severity = "warning";
+        // If defaultSeverity was set to false but we got here, i.e. the user set
+        // it to something that wasnt in SUPPORTED_SEVERITIES, that value has now
+        // been set to the default value – "warning".
+        // The event now does how have the default severity so we annotate it
+        // appropriately.
+        event.defaultSeverity = true;
     }
 
     if (Configuration.metaData && Object.keys(Configuration.metaData).length > 0) {

--- a/test/express.js
+++ b/test/express.js
@@ -35,9 +35,9 @@ describe("express middleware", function() {
     });
     port = app.listen().address().port;
     return request.get("http://localhost:" + port + "/ping", function(err, res, body) {
-      var req;
       assert(deliverStub.calledOnce);
-      req = deliverStub.firstCall.thisValue.events[0].metaData.request;
+      var event = deliverStub.firstCall.thisValue.events[0];
+      var req = event.metaData.request;
       assert.equal(req.url, "http://localhost:" + port + "/ping");
       assert.equal(req.path, "/ping");
       assert.equal(req.method, "GET");
@@ -46,6 +46,10 @@ describe("express middleware", function() {
       assert.notEqual(["127.0.0.1", "::ffff:127.0.0.1"].indexOf(req.connection.remoteAddress), -1);
       assert.equal(req.connection.localPort, port);
       assert.notEqual(["IPv4", "IPv6"].indexOf(req.connection.IPVersion), -1);
+      // check the event got the correct handled/unhandled properties set
+      assert.equal(event.unhandled, true);
+      assert.equal(event.severity, "error");
+      assert.deepEqual(event.severityReason, { type: "middleware_handler", name: "express/connect" });
       return next();
     });
   });

--- a/test/express.js
+++ b/test/express.js
@@ -18,10 +18,10 @@ describe("express middleware", function() {
   var deliverStub;
   deliverStub = null;
   beforeEach(function() {
-    return deliverStub = sinon.stub(Notification.prototype, "deliver");
+    return deliverStub = sinon.stub(Notification.prototype, "_deliver");
   });
   afterEach(function() {
-    return Notification.prototype.deliver.restore();
+    return Notification.prototype._deliver.restore();
   });
   return it("should automatically collect request data", function(next) {
     var app, port;
@@ -49,7 +49,7 @@ describe("express middleware", function() {
       // check the event got the correct handled/unhandled properties set
       assert.equal(event.unhandled, true);
       assert.equal(event.severity, "error");
-      assert.deepEqual(event.severityReason, { type: "middleware_handler", name: "express/connect" });
+      assert.deepEqual(event.severityReason, { type: "unhandledErrorMiddleware", attributes: { framework: "Express/Connect" } });
       return next();
     });
   });

--- a/test/lib/process-uncaught-exception.js
+++ b/test/lib/process-uncaught-exception.js
@@ -1,0 +1,12 @@
+var bugsnag = require("../../"),
+    Notification = require("../../lib/notification"),
+    sinon = require("sinon");
+
+bugsnag.register("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+var deliverStub = sinon.stub(Notification.prototype, "_deliver").yields(null, {});
+process.on("exit", function (code) {
+    process.send({ deliverCalled: deliverStub.called });
+});
+
+throw new Error("Boom");

--- a/test/lib/process-uncaught-exception.js
+++ b/test/lib/process-uncaught-exception.js
@@ -6,7 +6,10 @@ bugsnag.register("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
 var deliverStub = sinon.stub(Notification.prototype, "_deliver").yields(null, {});
 process.on("exit", function (code) {
-    process.send({ deliverCalled: deliverStub.called });
+    process.send({
+        deliverCalled: deliverStub.called,
+        payload: deliverStub.firstCall.thisValue
+    });
 });
 
 throw new Error("Boom");

--- a/test/lib/process-unhandled-rejection.js
+++ b/test/lib/process-unhandled-rejection.js
@@ -6,7 +6,10 @@ bugsnag.register("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
 
 var deliverStub = sinon.stub(Notification.prototype, "_deliver").yields(null, {});
 process.on("exit", function (code) {
-    process.send({ deliverCalled: deliverStub.called });
+    process.send({
+        deliverCalled: deliverStub.called,
+        payload: deliverStub.firstCall.thisValue
+    });
 });
 
 Promise.reject(new Error("boom"));

--- a/test/lib/process-unhandled-rejection.js
+++ b/test/lib/process-unhandled-rejection.js
@@ -1,0 +1,12 @@
+var bugsnag = require("../../"),
+    Notification = require("../../lib/notification"),
+    sinon = require("sinon");
+
+bugsnag.register("aaaaaaaaaaaaaaaaaaaaaaaaaaaaaaa");
+
+var deliverStub = sinon.stub(Notification.prototype, "_deliver").yields(null, {});
+process.on("exit", function (code) {
+    process.send({ deliverCalled: deliverStub.called });
+});
+
+Promise.reject(new Error("boom"));

--- a/test/notification.js
+++ b/test/notification.js
@@ -8,7 +8,8 @@ var path = require("path"),
     Notification = require("../lib/notification"),
     request = require("request"),
     apiKey = null,
-    deliverStub = null;
+    deliverStub = null,
+    child_process = require("child_process");
 
 before(function() {
     apiKey = "71ab53572c7b45316fb894d446f2e11d";
@@ -364,6 +365,34 @@ describe("Notification", function() {
                     }
                 });
                 throw new Error();
+            });
+        });
+    });
+
+    describe("dealing with process unhandled/uncaught events", function () {
+        it("should automatically report process#uncaughtException events", function (done) {
+            var p = child_process.fork(__dirname + "/lib/process-uncaught-exception.js");
+            var deliverCalled = false;
+            p.on("message", function (msg) {
+                deliverCalled = msg.deliverCalled;
+            });
+            p.on("exit", function (code) {
+                code.should.equal(1);
+                deliverCalled.should.equal(true);
+                done();
+            });
+        });
+
+        it("should automatically report process#unhandledRejection events", function (done) {
+            var p = child_process.fork(__dirname + "/lib/process-unhandled-rejection.js");
+            var deliverCalled = false;
+            p.on("message", function (msg) {
+                deliverCalled = msg.deliverCalled;
+            });
+            p.on("exit", function (code) {
+                code.should.equal(1);
+                deliverCalled.should.equal(true);
+                done();
             });
         });
     });

--- a/test/notification.js
+++ b/test/notification.js
@@ -351,6 +351,24 @@ describe("Notification", function() {
 
             Configuration.beforeNotifyCallbacks = [];
         });
+
+        it("should not be able to modify handledState", function () {
+            Bugsnag.onBeforeNotify(function (notification, error) {
+                notification.events[0].unhandled = true;
+                notification.events[0].defaultSeverity = false;
+            });
+            Bugsnag.notify(new Error('breaky'));
+            deliverStub.firstCall.thisValue.events[0].unhandled.should.equal(false);
+            deliverStub.firstCall.thisValue.events[0].defaultSeverity.should.equal(true);
+        });
+
+        it("should cause defaultSeverity=false if any callback changes severity", function () {
+          Bugsnag.onBeforeNotify(function (notification, error) {
+              notification.events[0].severity = "error";
+          });
+          Bugsnag.notify(new Error('breaky'));
+          deliverStub.firstCall.thisValue.events[0].defaultSeverity.should.equal(false);
+        })
     });
 
     describe("autoNotify", function() {


### PR DESCRIPTION
_Note this PR is based off of #115 since that is one of the main cases which requires unhandled info._

In order to support the upcoming handled/unhandled product feature this PR ensures that the following properties are set in the `events[]` property of the payload:

- `unhandled`
- `defaultSeverity`
- `severityReason` 

Since these properties are meant to be inferred and set internally by the notifier, but all internal usage went via `Bugsnag.notify()`, I extracted the contents of that function into one that is private (ie. within this module's scope only). The private function contains an additional argument `handledState` which cannot be set by the user, and when the public `Bugsnag.notify()` is called, values are inferred for `handledState` based on what was supplied.

There are a couple grey areas where functionality provided by this module is appeared at first to be "unhandled" and needed a `severityReason` etc.: `Bugsnag.intercept()`, `Bugsnag.autoNotify()`. In these instances, the captured errors are reported to via `Bugsnag.notify()` and therefore get `handledState` values applied as if the user had called the public function themselves.

(N.B. the `Bugsnag.autoNotify()` function is subtly different to the `autoNotify` option. Uncaught exceptions/promises will be reported as `unhandled=true` with `severity="error"` and the relevant `severityReason`.)