### PR TITLE
add error param to types for onBeforeNotify callback

### DIFF
--- a/lib/bugsnag.d.ts
+++ b/lib/bugsnag.d.ts
@@ -20,7 +20,7 @@ declare namespace bugsnag {
         autoNotify(cb: () => void): any;
         autoNotify(options: NotifyOptions, cb: () => void): any;
         shouldNotify(): boolean;
-        onBeforeNotify(cb: (notification: any) => boolean | void): void;
+        onBeforeNotify(cb: (notification: any) => boolean | void, error?: Error): void;
     }
 
     interface ConfigurationOptions {


### PR DESCRIPTION
Looks like the TypeScript definitions haven't caught up to the work that was done in #103 yet. This PR just updates the definition for `onBeforeNotify` so that it can optionally accept the original error as the second parameter.

![image](https://user-images.githubusercontent.com/1266011/31766698-3eba5f26-b4c0-11e7-8ef0-065592047661.png)
