### PR TITLE
Allow release stage ENV

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -20,7 +20,7 @@ var Configuration = {
     notifyPort: undefined,
     hostname: process.env.DYNO ? null : require("os").hostname(),
     apiKey: process.env.BUGSNAG_API_KEY,
-    releaseStage: process.env.NODE_ENV || "production",
+    releaseStage: process.env.BUGSNAG_RELEASE_STAGE || process.env.NODE_ENV || "production",
     appVersion: null,
     metaData: {},
     logger: new Logger(),


### PR DESCRIPTION
Currently the release stage is not different from the NODE_ENV. It really should be.