### PR TITLE
Ensure apiKey is sent in request body

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -210,14 +210,11 @@ Notification.prototype._deliver = function (cb) {
 };
 
 Notification.prototype.serializePayload = function() {
-    var apiKey = this.apiKey;
     var handledState = this.handledState;
-    delete this.apiKey;
     delete this.handledState;
     var payload = stringify(this, null, null, function() {
         return "[RECURSIVE]";
     });
-    this.apiKey = apiKey;
     this.handledState = handledState;
     return payload;
 }


### PR DESCRIPTION
Support older versions of Bugsnag on-premise that expect the error report contain the `apiKey` parameter in the body.