### PR TITLE
Apply metaData filters to request, app, user, device and breadcrumbs

### DIFF
--- a/lib/notification.js
+++ b/lib/notification.js
@@ -165,9 +165,6 @@ Notification.prototype._deliver = function (cb) {
         cb = null;
     }
 
-    // Filter before sending
-    this.events[0].metaData = Utils.filterObject(this.events[0].metaData, Configuration.filters);
-
     var port = Configuration.notifyPort || (Configuration.useSSL ? 443 : 80);
 
     Configuration.logger.info("Delivering exception to " + (Configuration.useSSL ? "https" : "http") + "://" + Configuration.notifyHost + ":" + port + Configuration.notifyPath);
@@ -212,6 +209,10 @@ Notification.prototype._deliver = function (cb) {
 Notification.prototype.serializePayload = function() {
     var handledState = this.handledState;
     delete this.handledState;
+    var event = this.events[0];
+    [ "user", "app", "metaData", "breadcrumbs", "request", "device" ].forEach(function (prop) {
+        event[prop] = Utils.filterObject(event[prop], Configuration.filters)
+    });
     var payload = stringify(this, null, null, function() {
         return "[RECURSIVE]";
     });


### PR DESCRIPTION
This PR ensures the values in `Configuration.filters` get applied to all places where sensitive issues could exist.

Fixes #127.