### PR TITLE
Don't call req.connection.address() if address is undefined

### DIFF
--- a/lib/request_info.js
+++ b/lib/request_info.js
@@ -2,7 +2,7 @@
 
 function requestInfo (req) {
     var connection = req.connection;
-    var address = connection && connection.address();
+    var address = connection && connection.address && connection.address();
     var portNumber = address && address.port;
     var port = !portNumber || portNumber === 80 || portNumber === 443 ? '' : ':' + portNumber;
     var full_url = req.protocol + "://" + (req.hostname || req.host) + port + req.url;


### PR DESCRIPTION
This PR ensures `req.connection.address()` is not called if `req.connection.address`  is `undefined`.

Fixes #129.