### PR TITLE
Improve logging clarity for unhandled exceptions

### DIFF
--- a/lib/bugsnag.js
+++ b/lib/bugsnag.js
@@ -73,7 +73,6 @@ function autoNotifyCallback(notifiedError, uncaughtError) {
                   errorMsg.push(notifiedError.stack);
                 }
             }
-            errorMsg.push("");
             Configuration.logger.error(errorMsg.join('\n'));
         }
         if (Configuration.onUncaughtError && uncaughtError) {

--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -32,11 +32,16 @@ var Configuration = {
     onUncaughtError: function(err) {
         if ((err instanceof Error) && err.domain) {
             if (err.domainThrown || err.domainEmitter || err.domainThrown === void 0) {
-            Configuration.logger.error(err.stack || err);
-            return process.exit(1);
+                var context = "";
+                if (err.domain._bugsnagOptions && err.domain._bugsnagOptions.cleanedRequest) {
+                    context += " at " + err.domain._bugsnagOptions.cleanedRequest.httpMethod
+                    context += " " + err.domain._bugsnagOptions.cleanedRequest.path + ""
+                }
+                Configuration.logger.error("Encountered an uncaught error" + context + " terminating…\n" + (err.stack || err));
+                return process.exit(1);
             }
         } else {
-            Configuration.logger.error(err.stack || err);
+            Configuration.logger.error("Encountered an uncaught error, terminating…\n" + (err.stack || err));
             return process.exit(1);
         }
     },


### PR DESCRIPTION
### Before

```
Bugsnag:  Error: flop
    at Object.<anonymous> (/Users/bengourley/Development/bugsnag-node/scratch/sig.js:3:7)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3)
    at Function.Module.runMain (module.js:609:10)
    at startup (bootstrap_node.js:158:16)
    at bootstrap_node.js:578:3
```

### After

```
Bugsnag:  Encountered an uncaught error, terminating…
Error: flop
    at Object.<anonymous> (/Users/bengourley/Development/bugsnag-node/scratch/sig.js:7:7)
    at Module._compile (module.js:573:30)
    at Object.Module._extensions..js (module.js:584:10)
    at Module.load (module.js:507:32)
    at tryModuleLoad (module.js:470:12)
    at Function.Module._load (module.js:462:3)
    at Function.Module.runMain (module.js:609:10)
    at startup (bootstrap_node.js:158:16)
    at bootstrap_node.js:578:3
```

Also some additional context has been added where available. In req/res handlers some info about the route is available on the error domain. Here's an example for a crash in an express route handler:

```
Bugsnag:  Encountered an uncaught error at GET / terminating…
Error: flop
    at Timeout.setTimeout [as _onTimeout] (/Users/bengourley/Development/bugsnag-node/scratch/express.js:6:28)
    at ontimeout (timers.js:469:11)
    at tryOnTimeout (timers.js:304:5)
    at Timer.listOnTimeout (timers.js:264:5)
```