### PR TITLE
feat(config): Support configuration of appType

### DIFF
--- a/lib/configuration.js
+++ b/lib/configuration.js
@@ -20,6 +20,7 @@ var Configuration = {
     apiKey: process.env.BUGSNAG_API_KEY,
     releaseStage: process.env.NODE_ENV || "production",
     appVersion: null,
+    appType: null,
     metaData: {},
     logger: new Logger(),
     sendCode: true,
@@ -56,6 +57,7 @@ var Configuration = {
         }
         Configuration.releaseStage = options.releaseStage || Configuration.releaseStage;
         Configuration.appVersion = options.appVersion || Configuration.appVersion;
+        Configuration.appType = options.appType || Configuration.appType;
         Configuration.autoNotifyUncaught = options.autoNotify != null ? options.autoNotify : Configuration.autoNotifyUncaught;
         Configuration.autoNotifyUnhandledRejection = options.autoNotifyUnhandledRejection === false ? false : (options.autoNotify != null ? options.autoNotify : Configuration.autoNotifyUnhandledRejection);
         Configuration.useSSL = options.useSSL != null ? options.useSSL : Configuration.useSSL;

--- a/lib/notification.js
+++ b/lib/notification.js
@@ -54,6 +54,11 @@ function Notification(bugsnagErrors, options, handledState) {
         event.app.version = Configuration.appVersion;
     }
 
+    if (Configuration.appType) {
+        if (!event.app) event.app = {};
+        event.app.type = Configuration.appType;
+    }
+
     if (Configuration.releaseStage) {
         if (!event.app) event.app = {};
         event.app.releaseStage = Configuration.releaseStage;

--- a/test/notification.js
+++ b/test/notification.js
@@ -217,6 +217,16 @@ describe("Notification", function() {
         });
     });
 
+    describe("appType", function() {
+        it("should send an appType when configured on Bugsnag", function() {
+            Bugsnag.configure({
+                appType: "worker"
+            });
+            Bugsnag.notify("This is the message");
+            deliverStub.firstCall.thisValue.events[0].app.type.should.equal("worker");
+        });
+    });
+
     describe("releaseStage", function() {
         it("shouldnt send a notification when releaseStage isnt configured in notifyReleaseStages", function() {
             Bugsnag.configure({


### PR DESCRIPTION
The error reporting payload supports app.type but this notifier didn't provide a way to set it. This change allows the app type setting to be set with the config option "appType".

Fixes #126.