### PR TITLE
Fixes Bugsnag.onBeforeNotify type definition

### DIFF
--- a/lib/bugsnag.d.ts
+++ b/lib/bugsnag.d.ts
@@ -20,7 +20,7 @@ declare namespace bugsnag {
         autoNotify(cb: () => void): any;
         autoNotify(options: NotifyOptions, cb: () => void): any;
         shouldNotify(): boolean;
-        onBeforeNotify(cb: (notification: any) => boolean | void, error?: Error): void;
+        onBeforeNotify(cb: (notification: any, error?: Error) => boolean | void): void;
     }
 
     interface ConfigurationOptions {


### PR DESCRIPTION
This fixes a small error in the `onBeforeNotify`'s argument type.