### PR TITLE
Fix types for the configuration object

### DIFF
--- a/lib/bugsnag.d.ts
+++ b/lib/bugsnag.d.ts
@@ -54,11 +54,12 @@ declare namespace bugsnag {
         info();
         warn();
         error();
+        debug();
     }
     
     interface Endpoints {
         notify: string;
-        sessions: string;
+        sessions?: string;
     }
 
     interface NotifyOptions {

--- a/lib/bugsnag.d.ts
+++ b/lib/bugsnag.d.ts
@@ -24,25 +24,41 @@ declare namespace bugsnag {
     }
 
     interface ConfigurationOptions {
-        logger?: any;
-        logLevel?: string;
-        releaseStage?: string;
+        appType?: string;
         appVersion?: string;
+        autoCaptureSessions?: boolean;
         autoNotify?: boolean;
-        useSSL?: boolean;
+        autoNotifyUnhandledRejection?: boolean;
+        endpoints?: Endpoints;
         filters?: string[];
-        notifyReleaseStages?: string[];
-        notifyHost?: string;
-        notifyPort?: number;
-        notifyPath?: string;
-        metaData?: { [key: string]: any };
-        onUncaughtError?(error: string | Error): void;
-        hostname?: string;
-        proxy?: string;
         headers?: { [key: string]: string };
-        projectRoot?: string;
+        hostname?: string;
+        logger?: Logger;
+        logLevel?: string;
+        metaData?: { [key: string]: any };
+        notifyHost?: string;
+        notifyPath?: string;
+        notifyPort?: number;
+        notifyReleaseStages?: string[];
+        onUncaughtError?(error: string | Error): void;
         packageJSON?: string;
+        projectRoot?: string;
+        proxy?: string;
+        releaseStage?: string;
         sendCode?: boolean;
+        sessionEndpoint?: string;
+        useSSL?: boolean;
+    }
+
+    interface Logger {
+        info();
+        warn();
+        error();
+    }
+    
+    interface Endpoints {
+        notify: string;
+        sessions: string;
     }
 
     interface NotifyOptions {


### PR DESCRIPTION
## Goal

With 2.4.0 the way in which URLs are configured has been changed. It looks like these types have not been updated in a while so I went through the documentation and updated them. I've added more detailed types to some of the properties that were `any` types. Lastly I've organized them alphabetically.

## Changeset

### Added
- `appType`
- `autoCaptureSessions`
- `autoNotifyUnhandledRejection`
- `endpoints`
- `sessionEndpoint`

### Removed

### Changed

- `logger`

## Tests

I changed this locally in my codebase and the types were recognized. That being said, I'm not using most of the options here, just 1 or two.

## Discussion

### Alternative Approaches

I could contribute this to DefinitelyTyped instead

## Review

For the submitter, initial self-review:

- [ ] Commented on code changes inline explain the reasoning behind the approach
- [ ] Reviewed the test cases added for completeness and possible points for discussion
- [ ] A changelog entry was added for the goal of this pull request
- [ ] Check the scope of the changeset - is everything in the diff required for the pull request?
- This pull request is ready for:
  - [ ] Initial review of the intended approach, not yet feature complete
  - [ ] Structural review of the classes, functions, and properties modified
  - [ ] Final review

For the pull request reviewer(s), this changeset has been reviewed for:

- [ ] Consistency across platforms for structures or concepts added or modified
- [ ] Consistency between the changeset and the goal stated above
- [ ] Internal consistency with the rest of the library - is there any overlap between existing interfaces and any which have been added?
- [ ] Usage friction - is the proposed change in usage cumbersome or complicated?
- [ ] Performance and complexity - are there any cases of unexpected O(n^3) when iterating, recursing, flat mapping, etc?
- [ ] Concurrency concerns - if components are accessed asynchronously, what issues will arise
- [ ] Thoroughness of added tests and any missing edge cases
- [ ] Idiomatic use of the language
