### PR TITLE
Fix TypeScript types: add a return type to logger methods

### DIFF
--- a/lib/bugsnag.d.ts
+++ b/lib/bugsnag.d.ts
@@ -51,12 +51,12 @@ declare namespace bugsnag {
     }
 
     interface Logger {
-        info();
-        warn();
-        error();
-        debug();
+        info(): void;
+        warn(): void;
+        error(): void;
+        debug(): void;
     }
-    
+
     interface Endpoints {
         notify: string;
         sessions?: string;


### PR DESCRIPTION
## Goal

In PR #144, the types for the TypeScript `Logger` interface were added, however the logger methods are missing return types.  This means TypeScript treats the return as implicit `any`, and for projects configured to not allow implicit `any`, that breaks the build.  The errors look like:

```
node_modules/bugsnag/lib/bugsnag.d.ts(54,9): error TS7010: 'info', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/bugsnag/lib/bugsnag.d.ts(55,9): error TS7010: 'warn', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/bugsnag/lib/bugsnag.d.ts(56,9): error TS7010: 'error', which lacks return-type annotation, implicitly has an 'any' return type.
node_modules/bugsnag/lib/bugsnag.d.ts(57,9): error TS7010: 'debug', which lacks return-type annotation, implicitly has an 'any' return type.
```

This PR sets the return types of the logger methods to `void`, which is also the return type of `console.log`:

```typescript
interface Logger {
    info(): void;
    warn(): void;
    error(): void;
    debug(): void;
}
```

## Changeset

### Changed

* `logger`

### Linked issues

Related to #144
